### PR TITLE
BJS2-27229 - Jacoco для post_service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     java
     id("org.springframework.boot") version "3.0.6"
     id("io.spring.dependency-management") version "1.1.0"
-    id("jacoco")
+    jacoco
 }
 
 group = "faang.school"
@@ -58,33 +58,71 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
-    /**
-     * Jacoco
-     */
+
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.0")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.0")
 }
 
+/**
+ * JaCoCo settings
+ */
+val jacocoInclude = listOf(
+    "**/controller/**",
+    "**/service/**",
+    "**/validator/**",
+    "**/mapper/**",
+    "**/filter/**",
+)
+
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.12"
 }
 
 tasks.test {
     finalizedBy(tasks.jacocoTestReport)
 }
 
+tasks.build {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}
+
+tasks.jacocoTestCoverageVerification {
+    mustRunAfter(tasks.jacocoTestReport)
+}
+
 tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+
     reports {
-        xml.required.set(true)
+        xml.required.set(false)
         csv.required.set(false)
-        html.outputLocation.set(file("${buildDir}/jacocoHtml"))
+        html.outputLocation.set(layout.buildDirectory.dir("jacocoHtml"))
     }
+
     classDirectories.setFrom(
-        fileTree(project.buildDir) {
-            include("**/post_service/service/**",
-                "**/post_service/validator/**",
-                "**/post_service/filter/**",
-                "**/post_service/controller/**")
+        sourceSets.main.get().output.asFileTree.matching {
+            include(jacocoInclude)
+        }
+    )
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = "BUNDLE"
+            enabled = true
+
+            limit {
+                counter = "INSTRUCTION"
+                value = "COVEREDRATIO"
+                minimum = "0.70".toBigDecimal()
+            }
+        }
+    }
+
+    classDirectories.setFrom(
+        sourceSets.main.get().output.asFileTree.matching {
+            include(jacocoInclude)
         }
     )
 }

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,8 @@
+# Прекращает поиск других конфигов Lombok
+# в родительских директориях
+config.stopBubbling = true
+
+# Добавляет аннотацию @lombok.Generated ко всему
+# коду, сгенерированному Lombok для исключения
+# проверки его покрытия при работе JaCoCo
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
Настройки в файле lombok.config позволяют исключить из проверки JaCoCo код, сгенерированный Lombok'ом.