### PR TITLE
BJS2-28471 - Публикация эвента лайка в Kafka

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("org.springframework:spring-aspects:6.1.11")
     implementation("org.springframework.retry:spring-retry:2.0.6")
     implementation("org.springframework.boot:spring-boot-starter-data-elasticsearch")
+    implementation("org.springframework.kafka:spring-kafka")
 
     /**
      * Database

--- a/src/main/java/faang/school/postservice/PostServiceApp.java
+++ b/src/main/java/faang/school/postservice/PostServiceApp.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.Banner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -14,6 +15,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableAsync
 @EnableRetry
+@EnableConfigurationProperties
 @EnableFeignClients(basePackages = "faang.school.postservice.client")
 @OpenAPIDefinition(info = @Info(
     title = "Post Service",

--- a/src/main/java/faang/school/postservice/config/kafka/KafkaProducerConfig.java
+++ b/src/main/java/faang/school/postservice/config/kafka/KafkaProducerConfig.java
@@ -1,0 +1,34 @@
+package faang.school.postservice.config.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/faang/school/postservice/config/kafka/KafkaTopicConfig.java
+++ b/src/main/java/faang/school/postservice/config/kafka/KafkaTopicConfig.java
@@ -1,0 +1,39 @@
+package faang.school.postservice.config.kafka;
+
+import faang.school.postservice.properties.KafkaTopicsProperties;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaAdmin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+public class KafkaTopicConfig {
+    private final KafkaTopicsProperties kafkaTopicsProperties;
+
+    @Value("${spring.kafka.topics.likes.name}")
+    private String likesName;
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public KafkaAdmin kafkaAdmin() {
+        Map<String, Object> configs = new HashMap<>();
+
+        configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        return new KafkaAdmin(configs);
+    }
+
+    @Bean
+    public NewTopic likesTopic() {
+        KafkaTopicsProperties.Topic likesTopic = kafkaTopicsProperties.getTopics().get(likesName);
+        return new NewTopic(likesTopic.getName(), likesTopic.getPartitions(), likesTopic.getReplicationFactor());
+    }
+}

--- a/src/main/java/faang/school/postservice/producer/AbstractKafkaProducer.java
+++ b/src/main/java/faang/school/postservice/producer/AbstractKafkaProducer.java
@@ -1,0 +1,23 @@
+package faang.school.postservice.producer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+
+@RequiredArgsConstructor
+public abstract class AbstractKafkaProducer<T> {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    private final NewTopic topic;
+
+    public void sendMessage(T message) {
+        try {
+            String messageJson = objectMapper.writeValueAsString(message);
+            kafkaTemplate.send(topic.name(), messageJson);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/faang/school/postservice/producer/KafkaLikeProducer.java
+++ b/src/main/java/faang/school/postservice/producer/KafkaLikeProducer.java
@@ -1,0 +1,15 @@
+package faang.school.postservice.producer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import faang.school.postservice.dto.like.LikeEvent;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaLikeProducer extends AbstractKafkaProducer<LikeEvent> {
+    public KafkaLikeProducer(KafkaTemplate<String, String> kafkaTemplate, ObjectMapper objectMapper, NewTopic likesTopic) {
+        super(kafkaTemplate, objectMapper, likesTopic);
+    }
+}
+

--- a/src/main/java/faang/school/postservice/properties/KafkaTopicsProperties.java
+++ b/src/main/java/faang/school/postservice/properties/KafkaTopicsProperties.java
@@ -1,0 +1,24 @@
+package faang.school.postservice.properties;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@ConfigurationProperties(prefix = "spring.kafka")
+@Getter
+@Setter
+public class KafkaTopicsProperties {
+    private Map<String, Topic> topics;
+
+    @Getter
+    @Setter
+    public static class Topic {
+        private String name;
+        private int partitions;
+        private short replicationFactor;
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -14,6 +14,17 @@ spring:
       hibernate:
         format_sql: true
 
+  kafka:
+    bootstrap-servers: localhost:9092
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+    topics:
+      likes:
+        name: likes
+        partitions: 1
+        replication-factor: 1
+
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
 
@@ -45,7 +56,6 @@ spring:
         field: hashtagNames
       field-for-range:
         field: id
-
     hashtag-cache:
       size:
         post-cache-size: 10


### PR DESCRIPTION
- Added Kafka configuration for KafkaTemplate and 'likes' topic
- Implemented KafkaLikeProducer to publish JSON event with post ID and author ID
- Event is published after like is saved in the database
- Created `KafkaTopicsProperties` for managing Kafka topics via configuration properties
- Added `AbstractKafkaProducer` to handle message publishing with ObjectMapper for JSON serialization