### PR TITLE
Bugfixes post_service

### DIFF
--- a/src/main/java/faang/school/postservice/api/client/CorrectorClient.java
+++ b/src/main/java/faang/school/postservice/api/client/CorrectorClient.java
@@ -4,9 +4,7 @@ import faang.school.postservice.dto.post.corrector.ApiResponse;
 import faang.school.postservice.dto.post.corrector.AutoCorrectionResponse;
 import faang.school.postservice.dto.post.corrector.CheckResponse;
 import faang.school.postservice.dto.post.corrector.LanguageResponse;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.retry.annotation.Backoff;
@@ -17,17 +15,17 @@ import org.springframework.web.reactive.function.client.WebClientException;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class CorrectorClient {
-
-    @Autowired
-    @Qualifier("correctorWebClient")
     private final WebClient webClient;
+
+    public CorrectorClient(@Qualifier("correctorWebClient") WebClient webClient) {
+        this.webClient = webClient;
+    }
 
     @Retryable(
             retryFor = {WebClientException.class},
             maxAttemptsExpression = "${post.grammar-checker.attempts}",
-            backoff = @Backoff(delayExpression = "${post.grammar-checker}",
+            backoff = @Backoff(delayExpression = "${post.grammar-checker.delay}",
                     multiplierExpression = "${post.grammar-checker.multiplier}"))
     public ApiResponse<LanguageResponse> getContentLanguageResponse(String content) {
         return webClient.get()
@@ -36,7 +34,8 @@ public class CorrectorClient {
                         .queryParam("text", content)
                         .build())
                 .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<ApiResponse<LanguageResponse>>() {})
+                .bodyToMono(new ParameterizedTypeReference<ApiResponse<LanguageResponse>>() {
+                })
                 .block();
     }
 
@@ -44,7 +43,7 @@ public class CorrectorClient {
     @Retryable(
             retryFor = {WebClientException.class},
             maxAttemptsExpression = "${post.grammar-checker.attempts}",
-            backoff = @Backoff(delayExpression = "${post.grammar-checker}",
+            backoff = @Backoff(delayExpression = "${post.grammar-checker.delay}",
                     multiplierExpression = "${post.grammar-checker.multiplier}"))
     public ApiResponse<AutoCorrectionResponse> getAutoCorrectedEnglishTextResponse(String content, String language) {
         return webClient.get()
@@ -54,14 +53,15 @@ public class CorrectorClient {
                         .queryParam("language", language)
                         .build())
                 .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<ApiResponse<AutoCorrectionResponse>>() {})
+                .bodyToMono(new ParameterizedTypeReference<ApiResponse<AutoCorrectionResponse>>() {
+                })
                 .block();
     }
 
     @Retryable(
             retryFor = {WebClientException.class},
             maxAttemptsExpression = "${post.grammar-checker.attempts}",
-            backoff = @Backoff(delayExpression = "${post.grammar-checker}",
+            backoff = @Backoff(delayExpression = "${post.grammar-checker.delay}",
                     multiplierExpression = "${post.grammar-checker.multiplier}"))
     public ApiResponse<CheckResponse> getCheckResponseForNonEnglishText(String content, String language) {
         return webClient.get()
@@ -71,7 +71,8 @@ public class CorrectorClient {
                         .queryParam("language", language)
                         .build())
                 .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<ApiResponse<CheckResponse>>() {})
+                .bodyToMono(new ParameterizedTypeReference<ApiResponse<CheckResponse>>() {
+                })
                 .block();
     }
 }

--- a/src/main/java/faang/school/postservice/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/postservice/config/redis/RedisConfig.java
@@ -47,7 +47,7 @@ public class RedisConfig {
     }
 
     @Bean(value = "likeChannel")
-    public ChannelTopic likeChannelTopic(@Value("${spring.data.redis.like-channel.name}") String name) {
+    public ChannelTopic likeChannelTopic(@Value("${spring.data.redis.channels.like-channel.name}") String name) {
         return new ChannelTopic(name);
     }
 

--- a/src/main/java/faang/school/postservice/dictionary/PostModerationDictionary.java
+++ b/src/main/java/faang/school/postservice/dictionary/PostModerationDictionary.java
@@ -13,11 +13,11 @@ import java.util.Set;
 @Slf4j
 @Getter
 @Component
-public class ModerationDictionary {
+public class PostModerationDictionary {
 
     private final Set<String> forbiddenWords = new HashSet<>();
 
-    public ModerationDictionary (@Value("${post.moderator.scheduler.dictionary.file}") Resource dictionaryResource) {
+    public PostModerationDictionary(@Value("${post.moderator.scheduler.dictionary.file}") Resource dictionaryResource) {
         try (BufferedReader bufferedReader = new BufferedReader(
                 new InputStreamReader(dictionaryResource.getInputStream()))) {
             bufferedReader.lines().forEach(line -> forbiddenWords.add(line.trim()));

--- a/src/main/java/faang/school/postservice/publisher/LikeEventPublisherImpl.java
+++ b/src/main/java/faang/school/postservice/publisher/LikeEventPublisherImpl.java
@@ -1,18 +1,23 @@
 package faang.school.postservice.publisher;
 
 import faang.school.postservice.dto.event.LikeEvent;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class LikeEventPublisherImpl implements MessagePublisher<LikeEvent> {
 
     private final RedisTemplate<String, LikeEvent> redisTemplate;
 
     private final ChannelTopic likeEventTopic;
+
+    public LikeEventPublisherImpl(RedisTemplate<String, LikeEvent> redisTemplate,
+                                  @Qualifier("likeChannel") ChannelTopic likeEventTopic) {
+        this.redisTemplate = redisTemplate;
+        this.likeEventTopic = likeEventTopic;
+    }
 
     @Override
     public void publish(LikeEvent event) {

--- a/src/main/java/faang/school/postservice/repository/PostRepository.java
+++ b/src/main/java/faang/school/postservice/repository/PostRepository.java
@@ -21,7 +21,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Query("SELECT p FROM Post p LEFT JOIN FETCH p.likes WHERE p.authorId = :authorId")
     List<Post> findByAuthorIdWithLikes(long authorId);
 
-    @Query("SELECT p FROM Post p WHERE p.verified_date = null AND p.deleted = false")
+    @Query("SELECT p FROM Post p WHERE p.verifiedDate = null AND p.deleted = false")
     List<Post> findNotVerified();
 
     @Query("SELECT p FROM Post p WHERE p.published = false AND p.deleted = false AND p.scheduledAt <= CURRENT_TIMESTAMP")

--- a/src/main/java/faang/school/postservice/scheduler/ModerationScheduler.java
+++ b/src/main/java/faang/school/postservice/scheduler/ModerationScheduler.java
@@ -1,4 +1,4 @@
-package faang.school.postservice.sheduler;
+package faang.school.postservice.scheduler;
 
 import faang.school.postservice.exception.post.ModeratingPostsException;
 import faang.school.postservice.service.post.PostService;

--- a/src/main/java/faang/school/postservice/service/comment/CommentChecker.java
+++ b/src/main/java/faang/school/postservice/service/comment/CommentChecker.java
@@ -29,7 +29,7 @@ public class CommentChecker {
 
     private final ByteBuffersDirectory buffersDirectory;
 
-    public CommentChecker(ModerationDictionary moderationDictionary) {
+    public CommentChecker(CommentModerationDictionary moderationDictionary) {
         this.buffersDirectory = new ByteBuffersDirectory();
         IndexWriterConfig config = new IndexWriterConfig(new StandardAnalyzer());
         try {

--- a/src/main/java/faang/school/postservice/service/comment/CommentModerationDictionary.java
+++ b/src/main/java/faang/school/postservice/service/comment/CommentModerationDictionary.java
@@ -13,11 +13,11 @@ import java.util.Set;
 
 @Getter
 @Component
-public class ModerationDictionary {
+public class CommentModerationDictionary {
 
     private final Set<String> obsceneWords;
 
-    public ModerationDictionary(@Value("${comment.obscene-words-resource}") String obsceneWordsResource,
+    public CommentModerationDictionary(@Value("${comment.obscene-words-resource}") String obsceneWordsResource,
                                 ObjectMapper objectMapper) {
         try (InputStream inputStream = getClass().getClassLoader().getResourceAsStream(obsceneWordsResource)) {
             obsceneWords = objectMapper.readValue(inputStream, new TypeReference<>() {

--- a/src/main/java/faang/school/postservice/service/post/impl/PostServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/post/impl/PostServiceImpl.java
@@ -44,9 +44,13 @@ public class PostServiceImpl implements PostService {
     private final UserServiceClient userClient;
     private final ProjectServiceClient projectClient;
     private final PostContentVerifier postContentVerifier;
+
+    @Setter
     @Value("${post.moderator.post-batch-size}")
     private int postBatchSize;
-    @Value(("{post.constants.post-max-size}"))
+
+    @Setter
+    @Value(("${post.constants.post-max-size}"))
     private int postMaxSize;
 
     @Setter

--- a/src/main/java/faang/school/postservice/service/post/impl/verifier/PostContentVerifierImpl.java
+++ b/src/main/java/faang/school/postservice/service/post/impl/verifier/PostContentVerifierImpl.java
@@ -1,6 +1,6 @@
 package faang.school.postservice.service.post.impl.verifier;
 
-import faang.school.postservice.dictionary.ModerationDictionary;
+import faang.school.postservice.dictionary.PostModerationDictionary;
 import faang.school.postservice.model.Post;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.service.post.PostContentVerifier;
@@ -18,13 +18,13 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class PostContentVerifierImpl implements PostContentVerifier {
 
-    private final ModerationDictionary moderationDictionary;
+    private final PostModerationDictionary postModerationDictionary;
     private final PostRepository postRepository;
 
     @Override
     @Async("taskExecutor")
     public void verifyPosts(List<Post> posts) {
-        Set<String> banWords = moderationDictionary.getForbiddenWords();
+        Set<String> banWords = postModerationDictionary.getForbiddenWords();
         for (Post post : posts) {
             boolean containsBanWord = banWords.stream()
                     .anyMatch(banWord -> post.getContent().toLowerCase().contains(banWord));

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -22,7 +22,7 @@ spring:
       port: 6379
       host: localhost
       channels:
-        like_channel:
+        like-channel:
           name: like_channel
         calculations_channel:
           name: calculations_channel
@@ -81,12 +81,11 @@ post:
   moderator:
     post-batch-size: 100
     scheduler:
-      cron: "0 0 * * *" # every day
+      cron: "0 0 * * * ?" # every day
       dictionary:
         file: "classpath:moderation-dictionary.txt"
   constants:
     post-max-size: 1000
-
   grammar-checker:
     scheduler:
       cron: "0 0 0 * * ?" # every day

--- a/src/test/java/faang/school/postservice/service/comment/CommentCheckerTest.java
+++ b/src/test/java/faang/school/postservice/service/comment/CommentCheckerTest.java
@@ -20,7 +20,7 @@ public class CommentCheckerTest {
     private CommentChecker commentChecker;
 
     @Mock
-    private ModerationDictionary moderationDictionary;
+    private CommentModerationDictionary moderationDictionary;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/faang/school/postservice/service/post/PostContentVerifierTest.java
+++ b/src/test/java/faang/school/postservice/service/post/PostContentVerifierTest.java
@@ -1,6 +1,6 @@
 package faang.school.postservice.service.post;
 
-import faang.school.postservice.dictionary.ModerationDictionary;
+import faang.school.postservice.dictionary.PostModerationDictionary;
 import faang.school.postservice.model.Post;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.service.post.impl.verifier.PostContentVerifierImpl;
@@ -21,7 +21,7 @@ import java.util.Set;
 public class PostContentVerifierTest {
 
     @Mock
-    private ModerationDictionary moderationDictionary;
+    private PostModerationDictionary postModerationDictionary;
 
     @Mock
     private PostRepository postRepository;
@@ -39,7 +39,7 @@ public class PostContentVerifierTest {
 
     @Test
     public void testVerifyPostsSuccess() {
-        when(moderationDictionary.getForbiddenWords()).thenReturn(banWords);
+        when(postModerationDictionary.getForbiddenWords()).thenReturn(banWords);
         post = Post.builder()
                 .id(1)
                 .authorId(2L)
@@ -55,7 +55,7 @@ public class PostContentVerifierTest {
 
     @Test
     public void testVerifyPostsContainBadWords() {
-        when(moderationDictionary.getForbiddenWords()).thenReturn(banWords);
+        when(postModerationDictionary.getForbiddenWords()).thenReturn(banWords);
         post = Post.builder()
                 .id(1)
                 .authorId(2L)


### PR DESCRIPTION
1) CorrectorClient:  дописал в @Retryable в delayExpression правильный путь
1.5) CorrectorClient: добавил конструктор с @Qualifier
2) RedisConfig: исправил @Value для likeChannelTopic
3) Было два класса ModerationDictionary, переименовал их в PostModerationDictionary и CommentModerationDictionary
4) LikeEventListener: добавил конструктор с @Qualifier для ChannelTopic
5) PostRepository: исправил @Query для метода findNotVerified (использовалось имя колонки в таблице вместо имени поля в entity)
6) PostServiceImpl: исправил @Value для postMaxSize (еще добавил недостающие сеттеры)
7) application.yaml: исправил название параметра like-channel
8) application.yaml: исправил cron выражение для модерации постов