### PR TITLE
[BJS2-41312] - publish posts on schedule

### DIFF
--- a/src/main/java/faang/school/postservice/config/threadpool/ThreadPoolConfig.java
+++ b/src/main/java/faang/school/postservice/config/threadpool/ThreadPoolConfig.java
@@ -1,0 +1,39 @@
+package faang.school.postservice.config.threadpool;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "spring.post-task.execution")
+public class ThreadPoolConfig {
+    @Getter
+    @Setter
+    public static class Pool {
+        private int coreSize;
+        private int maxSize;
+        private int queueCapacity;
+    }
+
+    private String threadNamePrefix;
+    private Pool pool;
+
+    @Bean
+    public ThreadPoolTaskExecutor postPublishExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(pool.getCoreSize());
+        executor.setMaxPoolSize(pool.getMaxSize());
+        executor.setQueueCapacity(pool.getQueueCapacity());
+        executor.setThreadNamePrefix(threadNamePrefix);
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.initialize();
+
+        return executor;
+    }
+
+}

--- a/src/main/java/faang/school/postservice/dto/post/PostDto.java
+++ b/src/main/java/faang/school/postservice/dto/post/PostDto.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDateTime;
+
 public record PostDto(
         @NotBlank(message = "Content should not be blank")
         @Size(max = 255, message = "Content must not exceed 255 characters")
@@ -11,5 +13,6 @@ public record PostDto(
         @Min(1)
         Long userId,
         @Min(1)
-        Long projectId) {
+        Long projectId,
+        LocalDateTime scheduledAt) {
 }

--- a/src/main/java/faang/school/postservice/mapper/PostMapper.java
+++ b/src/main/java/faang/school/postservice/mapper/PostMapper.java
@@ -22,7 +22,6 @@ public interface PostMapper {
     @Mapping(target = "resources", ignore = true)
     @Mapping(target = "published", ignore = true)
     @Mapping(target = "publishedAt", ignore = true)
-    @Mapping(target = "scheduledAt", ignore = true)
     @Mapping(target = "deleted", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)

--- a/src/main/java/faang/school/postservice/mapper/comment/CommentMapper.java
+++ b/src/main/java/faang/school/postservice/mapper/comment/CommentMapper.java
@@ -33,7 +33,7 @@ public interface CommentMapper {
     @Mapping(target = "likes", ignore = true)
     @Mapping(target = "post", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
-    @Mapping(target = "updatedAt", ignore = true)
+    @Mapping(target = "updatedAt", ignore = true )
     void update(CommentDto commentDto, @MappingTarget Comment comment);
 
     @Named("mapToLikeId")

--- a/src/main/java/faang/school/postservice/scheduler/post/ScheduledPostPublisher.java
+++ b/src/main/java/faang/school/postservice/scheduler/post/ScheduledPostPublisher.java
@@ -1,0 +1,17 @@
+package faang.school.postservice.scheduler.post;
+
+import faang.school.postservice.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ScheduledPostPublisher {
+    private final PostService postService;
+
+    @Scheduled(cron = "${post.publish-post.schedule.cron}")
+    public void publishPosts() {
+        postService.publishScheduledPosts();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,6 +18,13 @@ spring:
           max-size: 10
           queue-capacity: 25
         thread-name-prefix: checkPostsGrammarExecutor
+  post-task:
+    execution:
+      pool:
+        core-size: 10
+        max-size: 20
+        queue-capacity: 50
+      thread-name-prefix: postPublishExecutor
 
 
   jpa:
@@ -56,6 +63,10 @@ post:
     schedule:
       cron: "0 0 0 * * *"
     unverified-posts-limit: 5
+  publish-post:
+    schedule:
+      cron: "0 * * * * *"
+    batch-size: 1000
 
 user-service:
   host: localhost

--- a/src/test/java/faang/school/postservice/controller/PostControllerTest.java
+++ b/src/test/java/faang/school/postservice/controller/PostControllerTest.java
@@ -71,7 +71,7 @@ class PostControllerTest {
 
     @Test
     void createDraftPostByUserSuccessTest() throws Exception {
-        PostDto postDto = new PostDto("Test content", 1L, null);
+        PostDto postDto = new PostDto("Test content", 1L, null, null);
         Long expectedPostId = 1L;
         when(postService.createDraftPost(postDto)).thenReturn(1L);
 
@@ -86,7 +86,7 @@ class PostControllerTest {
 
     @Test
     void createDraftPostByProjectSuccessTest() throws Exception {
-        PostDto postDto = new PostDto("Test content", null, 3L);
+        PostDto postDto = new PostDto("Test content", null, 3L, null);
         Long expectedPostId = 2L;
         when(postService.createDraftPost(postDto)).thenReturn(2L);
 
@@ -101,7 +101,7 @@ class PostControllerTest {
 
     @Test
     void createDraftPostByUserContentIsBlankFailTest() throws Exception {
-        PostDto postDto = new PostDto("  ", 1L, null);
+        PostDto postDto = new PostDto("  ", 1L, null, null);
 
         mockMvc.perform(post(mainUrl)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -113,7 +113,7 @@ class PostControllerTest {
 
     @Test
     void createDraftPostByUserContentNullFailTest() throws Exception {
-        PostDto postDto = new PostDto(null, 1L, null);
+        PostDto postDto = new PostDto(null, 1L, null, null);
 
         mockMvc.perform(post(mainUrl)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -125,7 +125,7 @@ class PostControllerTest {
 
     @Test
     void createDraftPostByUserIdNullAndProjectIdNullFailTest() throws Exception {
-        PostDto postDto = new PostDto("Test for test", null, null);
+        PostDto postDto = new PostDto("Test for test", null, null, null);
 
         mockMvc.perform(post(mainUrl)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -136,7 +136,7 @@ class PostControllerTest {
 
     @Test
     void createDraftPostByUserIdAndProjectIdFailTest() throws Exception {
-        PostDto postDto = new PostDto("Test for test", 1L, 2L);
+        PostDto postDto = new PostDto("Test for test", 1L, 2L, null);
 
         mockMvc.perform(post(mainUrl)
                         .contentType(MediaType.APPLICATION_JSON)
@@ -147,7 +147,7 @@ class PostControllerTest {
 
     @Test
     void publishPostSuccessTest() throws Exception {
-        PostDto postDto = new PostDto("Test content", 1L, null);
+        PostDto postDto = new PostDto("Test content", 1L, null, null);
         Long postId = 1L;
 
         when(postService.publishPost(postId)).thenReturn(postDto);
@@ -214,12 +214,12 @@ class PostControllerTest {
 
     @Test
     void getPostSuccessTest() throws Exception {
+        Long postId = 1L;
 
-        PostDto postDto = new PostDto("Sample Post", 1L, 2L);
+        PostDto postDto = new PostDto("Sample Post", 1L, 2L, null);
         when(postService.getPost(anyLong())).thenReturn(postDto);
 
-        mockMvc.perform(get(mainUrl)
-                        .param("postId", String.valueOf(1L)))
+        mockMvc.perform(get(mainUrl + "/" + postId))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").value("Sample Post"))
                 .andExpect(jsonPath("$.userId").value(1L));
@@ -244,8 +244,8 @@ class PostControllerTest {
     void getDraftPostsByUserIdSuccessTest() throws Exception {
         Long userId = 1L;
         List<PostDto> drafts = List.of(
-                new PostDto("Draft 1", 1L, null),
-                new PostDto("Draft 2", 2L, null)
+                new PostDto("Draft 1", 1L, null, null),
+                new PostDto("Draft 2", 2L, null, null)
         );
         when(postService.getDraftPostsForUser(userId)).thenReturn(drafts);
 
@@ -284,8 +284,8 @@ class PostControllerTest {
     void getDraftPostsByProjectIdSuccessTest() throws Exception {
         Long projectId = 1L;
         List<PostDto> drafts = List.of(
-                new PostDto("Draft 1", null, 1L),
-                new PostDto("Draft 2", null, 2L)
+                new PostDto("Draft 1", null, 1L, null),
+                new PostDto("Draft 2", null, 2L, null)
         );
         when(postService.getDraftPostsForProject(projectId)).thenReturn(drafts);
 
@@ -324,8 +324,8 @@ class PostControllerTest {
     void getPublishedPostsByUserIdSuccessTest() throws Exception {
         Long userId = 1L;
         List<PostDto> drafts = List.of(
-                new PostDto("Publish 1", 1L, null),
-                new PostDto("Publish 2", 2L, null)
+                new PostDto("Publish 1", 1L, null, null),
+                new PostDto("Publish 2", 2L, null, null)
         );
         when(postService.getPublishedPostsForUser(userId)).thenReturn(drafts);
 
@@ -364,8 +364,8 @@ class PostControllerTest {
     void getPublishedPostsByProjectIdSuccessTest() throws Exception {
         Long projectId = 1L;
         List<PostDto> publishedPosts = List.of(
-                new PostDto("Post 1", null, 1L),
-                new PostDto("Post 2", null, 2L)
+                new PostDto("Post 1", null, 1L, null),
+                new PostDto("Post 2", null, 2L, null)
         );
         when(postService.getPublishedPostForProject(projectId)).thenReturn(publishedPosts);
 

--- a/src/test/java/faang/school/postservice/mapper/PostMapperTest.java
+++ b/src/test/java/faang/school/postservice/mapper/PostMapperTest.java
@@ -29,7 +29,7 @@ public class PostMapperTest {
 
     @Test
     void toEntity_ShouldMapPostDtoToPost() {
-        PostDto postDto = new PostDto( "Test Content", 10L, 20L);
+        PostDto postDto = new PostDto( "Test Content", 10L, 20L, null);
         Post post = postMapper.toEntity(postDto);
 
         assertNotNull(post);

--- a/src/test/java/faang/school/postservice/service/PostServiceTest.java
+++ b/src/test/java/faang/school/postservice/service/PostServiceTest.java
@@ -12,7 +12,6 @@ import feign.FeignException;
 import feign.Request;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.extern.log4j.Log4j2;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -22,10 +21,22 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @Log4j2
 @ExtendWith(MockitoExtension.class)
@@ -49,7 +60,7 @@ public class PostServiceTest {
     @Mock
     private UserContext userContext;
 
-    private final PostDto postDtoForUser = new PostDto("Test", 1L, null);
+    private final PostDto postDtoForUser = new PostDto("Test", 1L, null, null);
 
     @Captor
     ArgumentCaptor<PostViewEvent> postViewEventArgumentCaptor;
@@ -168,7 +179,7 @@ public class PostServiceTest {
     void updatePostSuccessTest() {
         Long postId = 1L;
         String updatedContent = "Updated content";
-        PostDto postDtoForUpdate = new PostDto(updatedContent, 1L, null);
+        PostDto postDtoForUpdate = new PostDto(updatedContent, 1L, null, null);
 
         Post existingPost = new Post();
         existingPost.setId(postId);
@@ -195,7 +206,7 @@ public class PostServiceTest {
     void updatePostNotFoundFailTest() {
         Long postId = 100L;
         String updatedContent = "Updated content";
-        PostDto postDtoForUpdate = new PostDto(updatedContent, 1L, null);
+        PostDto postDtoForUpdate = new PostDto(updatedContent, 1L, null, null);
 
         when(postRepository.findById(postId)).thenReturn(Optional.empty());
 
@@ -276,7 +287,7 @@ public class PostServiceTest {
         existingPost.setContent("Sample content");
         existingPost.setAuthorId(2L);
 
-        PostDto postDto = new PostDto("Sample content", 1L, null);
+        PostDto postDto = new PostDto("Sample content", 1L, null, null);
 
         when(postRepository.findById(postId)).thenReturn(Optional.of(existingPost));
         when(postMapper.toDto(existingPost)).thenReturn(postDto);
@@ -330,8 +341,8 @@ public class PostServiceTest {
         draftPost2.setDeleted(false);
         draftPost2.setCreatedAt(LocalDateTime.now());
 
-        PostDto draftPostDto1 = new PostDto("Dto 1", 1L, null);
-        PostDto draftPostDto2 = new PostDto("Dto 2", 2L, null);
+        PostDto draftPostDto1 = new PostDto("Dto 1", 1L, null, null);
+        PostDto draftPostDto2 = new PostDto("Dto 2", 2L, null, null);
 
         when(postRepository.findByAuthorId(userId)).thenReturn(List.of(draftPost1, draftPost2));
         when(postMapper.toDto(draftPost1)).thenReturn(draftPostDto1);


### PR DESCRIPTION
**ТЕСТЫ ОТСУТСТВУЮТ**

**Advanced 1: Фича — публикация постов по расписанию**
**Условия задачи**
Пользователи должны иметь возможность при создании поста запланировать его публикацию на определённые дату и время. Когда это время приходит, то приложение само автоматически публикует все посты, которые были запланированы к публикации.

**Тех. детали**
Всё делаем в post_service.

В PostDto нужно добавить новое поле: LocalDateTime scheduledAt. Оно будет показывать, на какие дату и время запланирован этот пост. Может быть null, если пост не был запланирован, а просто создаётся. Убедитесь, что это поле тоже корректно сохраняется/обновляется при создании/обновлении поста в существующих методах. Если там используется MapStruct, то проблем быть не должно.

Нужно создать бин ScheduledPostPublisher, который будет отвечать за регулярный запуск джобы по публикации запланированных постов. В нём используем аннотацию @Scheduled с cron-выражением, которое запускает этот метод каждую минуту. Не забываем добавить аннотацию @EnableScheduling, чтобы в приложении вообще стал доступен планировщик задач Spring.

ScheduledPostPublisher просто инжектит в себя PostService и в своём методе запуска джобы вызывает метод publishScheduledPosts() в PostService, который тоже необходимо там создать. Там и будет содержаться вся логика, а роль ScheduledPostPublisher — просто настроить регулярный запуск джобы. Очень простой класс.

В PostService в методе publishScheduledPosts() нужно сделать следующее:

Получить из БД все посты, которые ещё не были опубликованы и удалены, но у которых дата запланированной публикации больше текущей. Это можно сделать с помощью бина 

PostRepository и его готовых методов (см. ниже); • Запланированных постов может быть очень много. Если мы попытаемся опубликовать их все в одном потоке, то публикация может работать долго, и в результате их публикация будет позже, чем ожидают пользователи. Поэтому эту операцию публикации лучше распараллелить; • Разбить общий список всех полученных постов на подсписки, скажем, по 1000 постов и каждый подсписок будет публиковать в отдельном потоке. Но для этого нам сначала потребуется thread pool.

Создать класс ThreadPoolConfig, сделать его бином Spring конфигурации. Внутри этого класса создать бин пула потоков, в котором по умолчанию уже лежат 10 готовых трэдов. Это может быть, например, ExecutorService или ThreadPoolExecutor. Можно использовать методы для создания из класса Executors, но важно именно создать бин.

Инжектим этот бин пула потоков в PostService. Теперь в нашем publishScheduledPosts() мы можем запустить публикацию каждого подсписка постов в отдельном потоке из этого пула потоков. Сделать это можно любым удобным способом. Например, использовать CompletableFuture.runAsync.

Чтобы опубликовать конкретный пост, нужно обновить его поле published в true и проставить ему дату publishedAt в текущую. Когда все посты в подсписке обновлены этой информацией, можно применить метод сохранения всего подсписка в БД из PostRepository (см. ниже).

Максимально используем lombok для всего! Все зависимости между Spring bean должны быть проложены с помощью autowiring.

Для всех классов с логикой должны быть написаны unit-тесты, покрывающие всех их публичные методы. Используем JUnit и Mockito.

Готовые компоненты
Если вы не знакомы с логикой работы с БД (их мы будем проходить немного позже на буткемпе) и не готовы разбираться с ней самостоятельно прямо сейчас, то в проекте уже заранее создан интерфейс PostRepository со всеми методами, которые могут вам пригодиться в процессе реализации этого функционала

**Вот эти методы:**

findAll() — возвращает вообще все посты, которые есть в БД. Можете использовать его для получения всех постов, а затем с помощью Stream API отфильтровывать именно те, которые нужно опубликовать по условию задачи. Важно помнить, что это фильтрация в памяти. Если постов много, то работать это будет медленно. Используйте этот метод, только если хотите попрактиковаться в Stream API;

findReadyToPublish() — этот метод сразу возвращает список всех постов в БД, которые готовы к публикации (не опубликованы ранее, не удалены, а запланированная дата публикации у них раньше, чем текущее время);

saveAll(List<Post> posts) — сохраняет в БД все объекты из переданного списка post. Удобно использовать для быстрого сохранения сразу всего подсписка (батча) постов в отдельном потоке.