### PR TITLE
feat(kafka): Implement KafkaLikePublisher for like event publishing

### DIFF
--- a/src/main/java/faang/school/postservice/config/kafka/KafkaConfig.java
+++ b/src/main/java/faang/school/postservice/config/kafka/KafkaConfig.java
@@ -1,0 +1,35 @@
+package faang.school.postservice.config.kafka;
+
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/faang/school/postservice/publisher/KafkaLikePublisher.java
+++ b/src/main/java/faang/school/postservice/publisher/KafkaLikePublisher.java
@@ -1,0 +1,28 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.event.LikeEvent;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class KafkaLikePublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${spring.kafka.topic.like}")
+    private String likesTopic;
+
+    public void publishLikeEvent(long postAuthorId, long likeAuthorId, long postId) {
+        LikeEvent event = LikeEvent.builder()
+                .postAuthorId(postAuthorId)
+                .likeAuthorId(likeAuthorId)
+                .postId(postId)
+                .timestamp(LocalDateTime.now())
+                .build();
+        kafkaTemplate.send(likesTopic, event);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,7 +15,9 @@ spring:
         format_sql: true
   kafka:
     bootstrap-servers: localhost:9092
-
+    topic:
+      post:
+        like: likes
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
 


### PR DESCRIPTION
- Добавлена конфигурация Kafka (KafkaConfig) с ProducerFactory и KafkaTemplate.
- Создан KafkaLikePublisher, формирующий и отправляющий события лайка (LikeEvent) в топик "likes".
- Интегрирован вызов KafkaLikePublisher.publishLikeEvent в метод addLike после обновления кэша, с передачей необходимых идентификаторов.
- Получение userId из UserContext для формирования события.