### PR TITLE
BJS2-77485   Jacoco для post_service

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,36 @@ plugins {
     id("jacoco")
 }
 
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+        csv.required.set(false)
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            limit {
+                minimum = BigDecimal("0.70")
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}
+
 group = "faang.school"
 version = "1.0"
 java.sourceCompatibility = JavaVersion.VERSION_17
@@ -72,3 +102,5 @@ val test by tasks.getting(Test::class) { testLogging.showStandardStreams = true 
 tasks.bootJar {
     archiveFileName.set("service.jar")
 }
+
+


### PR DESCRIPTION
Added jacoco plugin with 70% test coverage. Я запустил ./gradlew build и проверил что он работает. Я пытался конфигурацию вывесть в другои фаил типо config-jacoco.gradle.kts и подтянуть их в build через apply() чтобы было крассивее но примерно 40 мин сражался с ошибками и в итоге полностью все сломалось так что оставил конфиги в build ))