### PR TITLE
BJS2-77887

### DIFF
--- a/src/main/java/faang/school/postservice/config/redis/RedisConfig.java
+++ b/src/main/java/faang/school/postservice/config/redis/RedisConfig.java
@@ -19,6 +19,8 @@ public class RedisConfig {
     private String postViewChannel;
     @Value("${spring.data.redis.channels.like}")
     private String likeChannel;
+    @Value("${spring.data.redis.channels.comment-analytics}")
+    private String commentAnalyticsChannel;
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(
@@ -49,5 +51,11 @@ public class RedisConfig {
     @Qualifier("likeTopic")
     public ChannelTopic likeTopic() {
         return new ChannelTopic(likeChannel);
+    }
+
+    @Bean
+    @Qualifier("commentAnalyticsTopic")
+    public ChannelTopic commentAnalyticsTopic() {
+        return new ChannelTopic(commentAnalyticsChannel);
     }
 }

--- a/src/main/java/faang/school/postservice/dto/event/CommentEventDto.java
+++ b/src/main/java/faang/school/postservice/dto/event/CommentEventDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Data
 @Builder
 @NoArgsConstructor
@@ -14,4 +16,5 @@ public class CommentEventDto {
     private Long postId;
     private Long authorId;
     private String text;
+    private LocalDateTime timestamp;
 }

--- a/src/main/java/faang/school/postservice/mapper/comment/CommentMapper.java
+++ b/src/main/java/faang/school/postservice/mapper/comment/CommentMapper.java
@@ -22,6 +22,7 @@ public interface CommentMapper {
     @Mapping(source = "id", target = "commentId")
     @Mapping(source = "post.id", target = "postId")
     @Mapping(source = "content", target = "text")
+    @Mapping(target = "timestamp", expression = "java(java.time.LocalDateTime.now())")
     CommentEventDto toCommentEventDto(Comment comment);
 
     default void updateCommentContent(@MappingTarget Comment comment, CommentDto commentDto) {

--- a/src/main/java/faang/school/postservice/publisher/comment/CommentAnalyticsEventPublisher.java
+++ b/src/main/java/faang/school/postservice/publisher/comment/CommentAnalyticsEventPublisher.java
@@ -1,0 +1,28 @@
+package faang.school.postservice.publisher.comment;
+
+import faang.school.postservice.dto.event.CommentEventDto;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Component;
+
+@Component("redisCommentAnalyticsEventPublisher")
+public class CommentAnalyticsEventPublisher implements CommentEventPublisher {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ChannelTopic commentAnalyticsTopic;
+
+    public CommentAnalyticsEventPublisher(
+            RedisTemplate<String, Object> redisTemplate,
+            @Qualifier("commentAnalyticsTopic") ChannelTopic commentAnalyticsTopic
+    ) {
+        this.redisTemplate = redisTemplate;
+        this.commentAnalyticsTopic = commentAnalyticsTopic;
+    }
+
+    @Override
+    public void publish(CommentEventDto event) {
+        redisTemplate.convertAndSend(commentAnalyticsTopic.getTopic(), event);
+    }
+}
+

--- a/src/main/java/faang/school/postservice/service/comment/CommentActionService.java
+++ b/src/main/java/faang/school/postservice/service/comment/CommentActionService.java
@@ -11,16 +11,22 @@ import org.springframework.stereotype.Component;
 public class CommentActionService {
 
     private final CommentEventPublisher commentEventPublisher;
+    private final CommentEventPublisher commentAnalyticsEventPublisher; // Добавить
     private final CommentMapper commentMapper;
 
     public CommentActionService(@Qualifier("redisCommentEventPublisher") CommentEventPublisher commentEventPublisher,
+                                @Qualifier("redisCommentAnalyticsEventPublisher")
+                                CommentEventPublisher commentAnalyticsEventPublisher,
                                 CommentMapper commentMapper) {
         this.commentEventPublisher = commentEventPublisher;
+        this.commentAnalyticsEventPublisher = commentAnalyticsEventPublisher;
         this.commentMapper = commentMapper;
     }
 
     public void registerNewComment(Comment comment) {
         CommentEventDto commentEventDto = commentMapper.toCommentEventDto(comment);
         commentEventPublisher.publish(commentEventDto);
+
+        commentAnalyticsEventPublisher.publish(commentEventDto);
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,7 @@ spring:
         comment: comment_channel
         postView: post_view_channel
         like: like_channel
+        comment-analytics: comment-analytics-channel
         calculations_channel:
           name: calculations_channel
 


### PR DESCRIPTION
- Создан новый класс для публикации аналитических событий комментариев `CommentAnalyticsEventPublisher`
- Добавлен канал `comment-analytics: comment-analytics-channel` в `application.yaml`
- В `RedisConfig.java` добавлено поле и bean `commentAnalyticsTopic()` `commentAnalyticsChannel`
- Добавлен второй publisher для аналитики
- Теперь при создании комментария событие публикуется в **два канала**: обычный и аналитический
- Добавлен маппинг для автоматического заполнения `timestamp` текущим временем