### PR TITLE
BJS2-96679 Jacoco done

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,3 +72,52 @@ val test by tasks.getting(Test::class) { testLogging.showStandardStreams = true 
 tasks.bootJar {
     archiveFileName.set("service.jar")
 }
+
+jacoco {
+    toolVersion = "0.8.13"
+}
+
+
+tasks.test {
+    finalizedBy(tasks.jacocoTestReport)
+}
+
+tasks.jacocoTestReport {
+    dependsOn(tasks.test)
+    reports {
+        xml.required.set(false)
+        csv.required.set(false)
+        html.required.set(true)
+        html.outputLocation.set(layout.buildDirectory.dir("jacocoHtml"))
+    }
+}
+
+tasks.jacocoTestCoverageVerification {
+    dependsOn(tasks.jacocoTestReport)
+
+    violationRules {
+        rule {
+            enabled = true
+            element = "CLASS"
+            includes = listOf(
+                "**Service**",
+                "**ServiceImpl**",
+            )
+
+            excludes = listOf(
+                "**PostServiceApp**"
+            )
+
+            limit {
+                counter = "INSTRUCTION"
+                value = "COVEREDRATIO"
+                minimum = "0.7".toBigDecimal()
+
+            }
+        }
+    }
+}
+
+tasks.check {
+    dependsOn(tasks.jacocoTestCoverageVerification)
+}


### PR DESCRIPTION
В случае если кто-то будет пользоваться JaCoCo. Принцип работы не хитрый, переходим во вкладку Gradle, там находим Verification -> нажимаем JacocoCoverageReport -> запускаются все тесты проекта.
После идем в папку build -> jacocoHtml -> пролистываем в самый низ и жмем на Index.html -> в окне выбираем удобный браузер и переходим на страницу в браузере, там все уже становится наглядно понятно

Если надо посмотреть запускаются ли тесты/если мешает JaCoCo - Закомментировать jacocoTestCoverageVerification в build.gradle.kts
Настроил, чтоб только по Service - классам тесты смотрел