### PR TITLE
feature-BJS2-96865-comment-analysis

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation("org.springframework:spring-aspects")
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
-
+    implementation("org.springframework.kafka:spring-kafka")
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
     implementation("org.springdoc:springdoc-openapi-starter-common:2.5.0")
     /**
@@ -81,6 +81,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.9.2")
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.kafka:spring-kafka-test")
 }
 
 tasks.test {

--- a/src/main/java/faang/school/postservice/dto/comment/CommentEventDto.java
+++ b/src/main/java/faang/school/postservice/dto/comment/CommentEventDto.java
@@ -1,0 +1,6 @@
+package faang.school.postservice.dto.comment;
+
+import java.time.LocalDateTime;
+
+public record CommentEventDto(long postId, long actorId, long commentId, long postAuthorId, LocalDateTime createdAt) {
+}

--- a/src/main/java/faang/school/postservice/publisher/EventsPublisher.java
+++ b/src/main/java/faang/school/postservice/publisher/EventsPublisher.java
@@ -14,13 +14,13 @@ import java.time.LocalDateTime;
 public class EventsPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
-    private static final String ANALYTICS_TOPIC = "analytics";
+    private static final String COMMENT_TOPIC = "comment-events";
 
     public void publishComment(long postId, long actorId, long commentId, long postAuthorId, LocalDateTime createdAt) {
         CommentEventDto event = new CommentEventDto(postId, actorId, commentId, postAuthorId, createdAt);
         log.info("Publishing comment event: postId={}, actorId={}, commentId={}, postAuthorId={}",  postId, actorId, commentId, postAuthorId);
         try {
-            kafkaTemplate.send(ANALYTICS_TOPIC, event);
+            kafkaTemplate.send(COMMENT_TOPIC, event);
             log.debug("Successfully published comment event: {}", event);
         } catch (Exception e) {
             log.error("Failed to publish comment event: {}", event, e);

--- a/src/main/java/faang/school/postservice/publisher/EventsPublisher.java
+++ b/src/main/java/faang/school/postservice/publisher/EventsPublisher.java
@@ -14,16 +14,16 @@ import java.time.LocalDateTime;
 public class EventsPublisher {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
-    private static final String COMMENT_TOPIC = "comment-events";
+    private static final String COMMENT_CREATE_TOPIC = "comment-create-events";
 
-    public void publishComment(long postId, long actorId, long commentId, long postAuthorId, LocalDateTime createdAt) {
+    public void publishCommentCreate(long postId, long actorId, long commentId, long postAuthorId, LocalDateTime createdAt) {
         CommentEventDto event = new CommentEventDto(postId, actorId, commentId, postAuthorId, createdAt);
-        log.info("Publishing comment event: postId={}, actorId={}, commentId={}, postAuthorId={}",  postId, actorId, commentId, postAuthorId);
+        log.info("Publishing comment create event: postId={}, actorId={}, commentId={}, postAuthorId={}",  postId, actorId, commentId, postAuthorId);
         try {
-            kafkaTemplate.send(COMMENT_TOPIC, event);
-            log.debug("Successfully published comment event: {}", event);
+            kafkaTemplate.send(COMMENT_CREATE_TOPIC, event);
+            log.debug("Successfully published comment create event: {}", event);
         } catch (Exception e) {
-            log.error("Failed to publish comment event: {}", event, e);
+            log.error("Failed to publish comment create event: {}", event, e);
         }
     }
 }

--- a/src/main/java/faang/school/postservice/publisher/EventsPublisher.java
+++ b/src/main/java/faang/school/postservice/publisher/EventsPublisher.java
@@ -1,0 +1,29 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.comment.CommentEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventsPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private static final String ANALYTICS_TOPIC = "analytics";
+
+    public void publishComment(long postId, long actorId, long commentId, long postAuthorId, LocalDateTime createdAt) {
+        CommentEventDto event = new CommentEventDto(postId, actorId, commentId, postAuthorId, createdAt);
+        log.info("Publishing comment event: postId={}, actorId={}, commentId={}, postAuthorId={}",  postId, actorId, commentId, postAuthorId);
+        try {
+            kafkaTemplate.send(ANALYTICS_TOPIC, event);
+            log.debug("Successfully published comment event: {}", event);
+        } catch (Exception e) {
+            log.error("Failed to publish comment event: {}", event, e);
+        }
+    }
+}

--- a/src/main/java/faang/school/postservice/service/CommentServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/CommentServiceImpl.java
@@ -73,7 +73,7 @@ public class CommentServiceImpl implements CommentService {
         Comment savedComment = commentRepository.save(comment);
 
         log.info("Created comment with id: {} for post with id: {} by user {}", savedComment.getId(), postId, userId);
-        eventsPublisher.publishComment(postId, userId, savedComment.getId(), post.getAuthorId(), LocalDateTime.now());
+        eventsPublisher.publishCommentCreate(postId, userId, savedComment.getId(), post.getAuthorId(), LocalDateTime.now());
         return commentMapper.toResponseDto(savedComment);
     }
 

--- a/src/main/java/faang/school/postservice/service/CommentServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/CommentServiceImpl.java
@@ -8,6 +8,7 @@ import faang.school.postservice.dto.user.UserDto;
 import faang.school.postservice.mapper.comment.CommentMapper;
 import faang.school.postservice.model.Comment;
 import faang.school.postservice.model.Post;
+import faang.school.postservice.publisher.EventsPublisher;
 import faang.school.postservice.repository.CommentRepository;
 import faang.school.postservice.repository.PostRepository;
 import feign.FeignException;
@@ -17,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -30,6 +32,7 @@ public class CommentServiceImpl implements CommentService {
     private final PostService postService;
     private final CommentMapper commentMapper;
     private final UserServiceClient userServiceClient;
+    private final EventsPublisher eventsPublisher;
 
     @Override
     @Transactional(readOnly = true)
@@ -68,8 +71,9 @@ public class CommentServiceImpl implements CommentService {
         comment.setAuthorId(userId);
 
         Comment savedComment = commentRepository.save(comment);
-        log.info("Created comment with id: {} for post with id: {} by user {}", savedComment.getId(), postId, userId);
 
+        log.info("Created comment with id: {} for post with id: {} by user {}", savedComment.getId(), postId, userId);
+        eventsPublisher.publishComment(postId, userId, savedComment.getId(), post.getAuthorId(), LocalDateTime.now());
         return commentMapper.toResponseDto(savedComment);
     }
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,16 @@
 spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+    properties:
+      security:
+        protocol: PLAINTEXT
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      acks: all
+      properties:
+        spring.json.add.type.headers: false
+
   servlet:
     multipart:
       enabled: true
@@ -92,14 +104,3 @@ languagetool:
   api-url: "https://api.languagetool.org"
   language: "auto"
 
-kafka:
-  bootstrap-servers: localhost:9092
-  properties:
-    security:
-      protocol: PLAINTEXT
-  producer:
-    key-serializer: org.apache.kafka.common.serialization.StringSerializer
-    value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-    acks: all
-    properties:
-      spring.json.add.type.headers: false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -91,3 +91,15 @@ post-correcter:
 languagetool:
   api-url: "https://api.languagetool.org"
   language: "auto"
+
+kafka:
+  bootstrap-servers: localhost:9092
+  properties:
+    security:
+      protocol: PLAINTEXT
+  producer:
+    key-serializer: org.apache.kafka.common.serialization.StringSerializer
+    value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    acks: all
+    properties:
+      spring.json.add.type.headers: false

--- a/src/test/java/faang/school/postservice/util/service/comment/CommentServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/service/comment/CommentServiceImplTest.java
@@ -125,7 +125,7 @@ public class CommentServiceImplTest {
         verify(commentMapper).toEntity(createDto);
         verify(commentRepository).save(any(Comment.class));
         verify(commentMapper).toResponseDto(testComment);
-        verify(eventsPublisher).publishComment(eq(POST_ID), eq(USER_ID),
+        verify(eventsPublisher).publishCommentCreate(eq(POST_ID), eq(USER_ID),
                 eq(testComment.getId()), eq(testPost.getAuthorId()), any(LocalDateTime.class));
     }
 

--- a/src/test/java/faang/school/postservice/util/service/comment/CommentServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/service/comment/CommentServiceImplTest.java
@@ -8,6 +8,7 @@ import faang.school.postservice.dto.user.UserDto;
 import faang.school.postservice.mapper.comment.CommentMapper;
 import faang.school.postservice.model.Comment;
 import faang.school.postservice.model.Post;
+import faang.school.postservice.publisher.EventsPublisher;
 import faang.school.postservice.repository.CommentRepository;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.service.CommentServiceImpl;
@@ -31,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -53,7 +55,7 @@ public class CommentServiceImplTest {
     private static final String BLANK_CONTENT = "   ";
     private static final String LONG_CONTENT = "а".repeat(4097);
 
-    private final Post testPost = Post.builder().id(POST_ID).build();
+    private final Post testPost = Post.builder().id(POST_ID).authorId(456L).build();
     private final Comment testComment = Comment.builder()
             .id(COMMENT_ID)
             .content(CONTENT)
@@ -62,6 +64,9 @@ public class CommentServiceImplTest {
             .createdAt(LocalDateTime.now().minusHours(1))
             .updatedAt(LocalDateTime.now().minusHours(1))
             .build();
+
+    @Mock
+    private EventsPublisher eventsPublisher;
 
     @Mock
     private CommentRepository commentRepository;
@@ -120,6 +125,8 @@ public class CommentServiceImplTest {
         verify(commentMapper).toEntity(createDto);
         verify(commentRepository).save(any(Comment.class));
         verify(commentMapper).toResponseDto(testComment);
+        verify(eventsPublisher).publishComment(eq(POST_ID), eq(USER_ID),
+                eq(testComment.getId()), eq(testPost.getAuthorId()), any(LocalDateTime.class));
     }
 
     @Test


### PR DESCRIPTION
Задание
analytics_service должен собирать информацию о комментариях поста пользователя/проекта другими юзерами в post_service:

Создать Spring-конфигурацию Kafka топика и реализацию CommentEventPublisher — отправителя события CommentEvent в post_service. Туториал: PubSub Messaging with Spring Data Kafka | Baeldung 

Отправлять событие CommentEvent через CommentEventPublisher в момент, когда пользователь комментит пост другого пользователя — вызывает соответствующий эндпоинт. В событии содержатся: id поста; id автора; id коммента; дата и время.

В analytics_service создать конфигурацию слушателя эвентов CommentEventListener для CommentEvent, руководствуясь тем же тутором выше.

CommentEventListener слушает события CommentEvent и сохраняет информацию из этих событий с БД, используя AnalyticsEventService для выполнения логики сохранения и AnalyticsEvent для превращения CommentEvent в сущность БД. Используем AnalyticsEventMapper для такого превращения.
