### PR TITLE
feature-BJS2-97871-publication-event-post

### DIFF
--- a/.github/workflows/ci-prs.yaml
+++ b/.github/workflows/ci-prs.yaml
@@ -41,7 +41,8 @@ jobs:
       - name: Checkstyle verification
         run: ./gradlew checkstyleMain checkstyleTest --no-daemon --continue
 
-
+      - name: Test with Gradle
+        run: ./gradlew test -x testClasses --no-daemon --continue
 
       - name: Archive test report
         if: always()
@@ -57,8 +58,6 @@ jobs:
           name: checkstyle_report
           path: build/reports/checkstyle
 
-      - name: Test with Gradle
-        run: ./gradlew test -x testClasses --no-daemon --continue
 
       - name: Generate Jacoco Report
         run: ./gradlew jacocoTestReport --no-daemon --continue

--- a/.github/workflows/ci-prs.yaml
+++ b/.github/workflows/ci-prs.yaml
@@ -2,7 +2,7 @@ name: Check PRs
 
 on:
   pull_request:
-    branches: [ chimera-master-stream12 ]
+    branches: [ chimera-stream12-news-feed-elya ]
     types: [ opened, reopened, synchronize, edited ]
 
 permissions:

--- a/src/main/java/faang/school/postservice/client/UserServiceClient.java
+++ b/src/main/java/faang/school/postservice/client/UserServiceClient.java
@@ -19,4 +19,13 @@ public interface UserServiceClient {
 
     @GetMapping("/users")
     List<UserDto> getUsersByIds(@RequestParam("ids") List<Long> ids);
+
+    @GetMapping("/subscriptions/{followeeId}/followers")
+    List<UserDto> getFollowers(
+            @PathVariable long followeeId,
+            @RequestParam(required = false) String namePattern,
+            @RequestParam(required = false) String phonePattern,
+            @RequestParam(defaultValue = "0") int experienceMin,
+            @RequestParam(defaultValue = "2147483647") int experienceMax
+    );
 }

--- a/src/main/java/faang/school/postservice/dto/post/PostEventDto.java
+++ b/src/main/java/faang/school/postservice/dto/post/PostEventDto.java
@@ -1,13 +1,25 @@
 package faang.school.postservice.dto.post;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record PostEventDto(
+        @NotNull(message = "Post ID cannot be null")
         Long postId,
         Long authorId,
         Long projectId,
+        @NotNull(message = "Follower IDs list cannot be null")
         List<Long> followerIds,
+        @NotNull(message = "Published timestamp cannot be null")
         LocalDateTime publishedAt
 ) {
+    @AssertTrue(message = "Must be sent only one field: authorId or projectId")
+    @Schema(hidden = true)
+    public boolean isExactlyOneAuthor() {
+        return (authorId != null) ^ (projectId != null);
+    }
 }

--- a/src/main/java/faang/school/postservice/dto/post/PostEventDto.java
+++ b/src/main/java/faang/school/postservice/dto/post/PostEventDto.java
@@ -1,0 +1,13 @@
+package faang.school.postservice.dto.post;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PostEventDto(
+        Long postId,
+        Long authorId,
+        Long projectId,
+        List<Long> followerIds,
+        LocalDateTime publishedAt
+) {
+}

--- a/src/main/java/faang/school/postservice/publisher/KafkaPostProducer.java
+++ b/src/main/java/faang/school/postservice/publisher/KafkaPostProducer.java
@@ -1,0 +1,27 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaPostProducer {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private static final String POSTS_CREATE_TOPIC = "posts";
+
+    public void publishPostCreate(PostEventDto event) {
+        log.info("Publishing post create event: postId={}, authorId={}, followerCount={}",
+                event.postId(), event.authorId(), event.followerIds() == null ? 0 : event.followerIds().size());
+        try {
+            kafkaTemplate.send(POSTS_CREATE_TOPIC, event);
+            log.debug("Successfully published post create event: {}", event);
+        } catch (Exception e) {
+            log.error("Failed to publish post create event: {}", event, e);
+        }
+    }
+}

--- a/src/main/java/faang/school/postservice/publisher/KafkaPostProducer.java
+++ b/src/main/java/faang/school/postservice/publisher/KafkaPostProducer.java
@@ -3,8 +3,12 @@ package faang.school.postservice.publisher;
 import faang.school.postservice.dto.post.PostEventDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Component
@@ -12,16 +16,27 @@ import org.springframework.stereotype.Component;
 public class KafkaPostProducer {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
-    private static final String POSTS_CREATE_TOPIC = "posts";
+
+    @Value("${kafka.producer.timeout-seconds:3}")
+    private long timeoutSeconds;
+
+    @Value("${kafka.topics.posts}")
+    private String postsTopicName;
 
     public void publishPostCreate(PostEventDto event) {
         log.info("Publishing post create event: postId={}, authorId={}, followerCount={}",
                 event.postId(), event.authorId(), event.followerIds() == null ? 0 : event.followerIds().size());
         try {
-            kafkaTemplate.send(POSTS_CREATE_TOPIC, event);
-            log.debug("Successfully published post create event: {}", event);
+            SendResult<String, Object> result = kafkaTemplate.send(postsTopicName, event)
+                    .get(timeoutSeconds, TimeUnit.SECONDS);
+            log.info("Successfully published: postId={}, offset={}", event.postId(),
+                    result.getRecordMetadata().offset());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Kafka publish interrupted", e);
         } catch (Exception e) {
             log.error("Failed to publish post create event: {}", event, e);
+            throw new RuntimeException("Failed to publish post event", e);
         }
     }
 }

--- a/src/main/java/faang/school/postservice/publisher/KafkaPostProducer.java
+++ b/src/main/java/faang/school/postservice/publisher/KafkaPostProducer.java
@@ -8,7 +8,9 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 @Slf4j
 @Component
@@ -17,10 +19,10 @@ public class KafkaPostProducer {
 
     private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    @Value("${kafka.producer.timeout-seconds:3}")
+    @Value("${app.producer.timeout-seconds:3}")
     private long timeoutSeconds;
 
-    @Value("${kafka.topics.posts}")
+    @Value("${app.kafka.topics.posts-create-topic}")
     private String postsTopicName;
 
     public void publishPostCreate(PostEventDto event) {
@@ -29,14 +31,20 @@ public class KafkaPostProducer {
         try {
             SendResult<String, Object> result = kafkaTemplate.send(postsTopicName, event)
                     .get(timeoutSeconds, TimeUnit.SECONDS);
-            log.info("Successfully published: postId={}, offset={}", event.postId(),
-                    result.getRecordMetadata().offset());
+            log.info("Successfully published: postId={}, offset={}, partition={}", event.postId(),
+                    result.getRecordMetadata().offset(), result.getRecordMetadata().partition());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            log.error("Kafka publish interrupted for postId={}", event.postId(), e);
             throw new RuntimeException("Kafka publish interrupted", e);
-        } catch (Exception e) {
-            log.error("Failed to publish post create event: {}", event, e);
+        } catch (ExecutionException e) {
+            log.error("Failed to publish post create event: postId={}, authorId={}, cause={}", event.postId(),
+                    event.authorId(), e.getCause() != null ? e.getCause().getMessage() : e.getMessage(), e);
             throw new RuntimeException("Failed to publish post event", e);
+        } catch (TimeoutException e) {
+            log.error("Kafka publish timeout for postId={} after {} seconds",
+                    event.postId(), timeoutSeconds, e);
+            throw new RuntimeException("Kafka publish timeout", e);
         }
     }
 }

--- a/src/main/java/faang/school/postservice/publisher/PostPublishedEventListener.java
+++ b/src/main/java/faang/school/postservice/publisher/PostPublishedEventListener.java
@@ -1,0 +1,25 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostPublishedEventListener {
+
+    private final KafkaPostProducer kafkaProducer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handlePostPublished(PostEventDto event) {
+        try {
+            kafkaProducer.publishPostCreate(event);
+        } catch (Exception e) {
+            log.error("Failed to send to Kafka: postId={}", event.postId(), e);
+        }
+    }
+}

--- a/src/main/java/faang/school/postservice/service/PostServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/PostServiceImpl.java
@@ -366,10 +366,10 @@ public class PostServiceImpl implements PostService {
             return Collections.emptyList();
         } catch (FeignException e) {
             log.error("Failed to get followers from user-service for author {}", authorId, e);
-            return Collections.emptyList();
+            throw new RuntimeException("Cannot fetch followers - user-service unavailable", e);
         } catch (Exception e) {
             log.error("Unexpected error when searching for followers for an author {}", authorId, e);
-            return Collections.emptyList();
+            throw new RuntimeException("Cannot fetch followers - unexpected error", e);
         }
     }
 }

--- a/src/main/java/faang/school/postservice/service/PostServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/PostServiceImpl.java
@@ -18,13 +18,13 @@ import faang.school.postservice.exception.ProjectNotFoundException;
 import faang.school.postservice.exception.UserNotFoundException;
 import faang.school.postservice.mapper.post.PostMapper;
 import faang.school.postservice.model.Post;
-import faang.school.postservice.publisher.KafkaPostProducer;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.scheduler.ThreadPoolConfig;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
@@ -57,7 +57,7 @@ public class PostServiceImpl implements PostService {
     private final FeignLanguageToolClient feignLanguageTool;
     private final UserContext userContext;
     private final ThreadPoolConfig threadPoolConfig;
-    private final KafkaPostProducer kafkaPostProducer;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Value("${scheduler.thread-pool.batchSize:50}")
     private int batchSize;
@@ -131,7 +131,7 @@ public class PostServiceImpl implements PostService {
                 saved.getPublishedAt()
         );
 
-        kafkaPostProducer.publishPostCreate(event);
+        eventPublisher.publishEvent(event);
         return postMapper.toDto(saved);
     }
 

--- a/src/main/java/faang/school/postservice/service/PostServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/PostServiceImpl.java
@@ -6,6 +6,7 @@ import faang.school.postservice.client.UserServiceClient;
 import faang.school.postservice.config.context.LanguageToolConfig;
 import faang.school.postservice.config.context.UserContext;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
+import faang.school.postservice.dto.post.PostEventDto;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.post.PostResponseDto;
 import faang.school.postservice.dto.project.ProjectDto;
@@ -17,6 +18,7 @@ import faang.school.postservice.exception.ProjectNotFoundException;
 import faang.school.postservice.exception.UserNotFoundException;
 import faang.school.postservice.mapper.post.PostMapper;
 import faang.school.postservice.model.Post;
+import faang.school.postservice.publisher.KafkaPostProducer;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.scheduler.ThreadPoolConfig;
 import feign.FeignException;
@@ -32,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -54,6 +57,7 @@ public class PostServiceImpl implements PostService {
     private final FeignLanguageToolClient feignLanguageTool;
     private final UserContext userContext;
     private final ThreadPoolConfig threadPoolConfig;
+    private final KafkaPostProducer kafkaPostProducer;
 
     @Value("${scheduler.thread-pool.batchSize:50}")
     private int batchSize;
@@ -118,6 +122,16 @@ public class PostServiceImpl implements PostService {
         Post saved = postRepository.save(post);
 
         log.info("Post published id={} at {}", id, saved.getPublishedAt());
+        List<Long> followerIds = getFollowerIds(saved.getAuthorId());
+        PostEventDto event = new PostEventDto(
+                saved.getId(),
+                saved.getAuthorId(),
+                saved.getProjectId(),
+                followerIds,
+                saved.getPublishedAt()
+        );
+
+        kafkaPostProducer.publishPostCreate(event);
         return postMapper.toDto(saved);
     }
 
@@ -328,5 +342,34 @@ public class PostServiceImpl implements PostService {
             result.add(ready.subList(i, Math.min(i + batchSize, size)));
         }
         return result;
+    }
+
+    private List<Long> getFollowerIds(Long authorId) {
+        if (authorId == null) {
+            log.warn("AuthorId is null, can't find followers");
+            return Collections.emptyList();
+        }
+
+        try {
+            List<UserDto> followers = userServiceClient.getFollowers(
+                    authorId,
+                    null,
+                    null,
+                    0,
+                    Integer.MAX_VALUE
+            );
+            return followers.stream()
+                    .map(UserDto::id)
+                    .collect(Collectors.toList());
+        } catch (FeignException.NotFound e) {
+            log.warn("User {} not found when getting followers", authorId);
+            return Collections.emptyList();
+        } catch (FeignException e) {
+            log.error("Failed to get followers from user-service for author {}", authorId, e);
+            return Collections.emptyList();
+        } catch (Exception e) {
+            log.error("Unexpected error when searching for followers for an author {}", authorId, e);
+            return Collections.emptyList();
+        }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -68,7 +68,7 @@ logging:
 app:
   kafka:
     topics:
-      posts-create-topic: posts
+      posts-create-topic: posts-create-topic
   producer:
     timeout-seconds: 3
   resources:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,11 +65,18 @@ logging:
   level:
     root: info
 
-kafka:
-  topics:
-    posts: posts
+app:
+  kafka:
+    topics:
+      posts-create-topic: posts
   producer:
-        timeout-seconds: 3
+    timeout-seconds: 3
+  resources:
+    image:
+      max-file-size-mb: 5
+      max-per-post: 10
+      type: "IMAGE"
+
 user-service:
   host: localhost
   port: 8080
@@ -98,13 +105,6 @@ services:
     accessKey: user
     secretKey: password
     bucketName: corpbucket
-
-app:
-  resources:
-    image:
-      max-file-size-mb: 5
-      max-per-post: 10
-      type: "IMAGE"
 
 post-correcter:
   cron: "0 0 3 * * *" # every day at 3:00

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,10 @@ spring:
       acks: all
       properties:
         spring.json.add.type.headers: false
+        max.block.ms: 3000
+        delivery.timeout.ms: 10000
+        request.timeout.ms: 5000
+        enable.idempotence: true
 
   servlet:
     multipart:
@@ -61,6 +65,11 @@ logging:
   level:
     root: info
 
+kafka:
+  topics:
+    posts: posts
+  producer:
+        timeout-seconds: 3
 user-service:
   host: localhost
   port: 8080

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -46,7 +46,7 @@ spring:
 
 scheduler:
   cron:
-    expression: 0 * * * * *
+    expression: 0 0 * * * *
     zone: GMT
   thread-pool:
     size: 10

--- a/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
@@ -6,6 +6,7 @@ import faang.school.postservice.client.UserServiceClient;
 import faang.school.postservice.config.context.LanguageToolConfig;
 import faang.school.postservice.config.context.UserContext;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
+import faang.school.postservice.dto.post.PostEventDto;
 import faang.school.postservice.dto.post.PostResponseDto;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.project.ProjectDto;
@@ -16,6 +17,7 @@ import faang.school.postservice.dto.user.UserDto;
 import faang.school.postservice.exception.EntityNotFoundException;
 import faang.school.postservice.mapper.post.PostMapper;
 import faang.school.postservice.model.Post;
+import faang.school.postservice.publisher.KafkaPostProducer;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.scheduler.ThreadPoolConfig;
 import faang.school.postservice.service.PostServiceImpl;
@@ -46,6 +48,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -63,6 +66,8 @@ class PostServiceImplTest {
     private static final long AUTHOR_ID = 10L;
     private static final long PROJECT_ID = 7L;
     private static final long SAVED_ID = 42L;
+    private static final long FOLLOWER_1_ID = 100L;
+    private static final long FOLLOWER_2_ID = 200L;
 
     private static final String CONTENT = "Hello";
     private static final String CONTENT_CREATE = "Hi";
@@ -92,6 +97,8 @@ class PostServiceImplTest {
     private FeignLanguageToolClient feignLanguageTool;
     @Mock
     private UserContext userContext;
+    @Mock
+    private KafkaPostProducer kafkaPostProducer;
     @Spy
     private PostMapper postMapper = Mappers.getMapper(PostMapper.class);
     private Post postDbEntity;
@@ -215,10 +222,11 @@ class PostServiceImplTest {
     void publish_ok() {
         when(postRepository.findById(POST_ID)).thenReturn(Optional.of(postDbEntity));
         when(postRepository.save(any(Post.class))).thenAnswer(inv -> inv.getArgument(0));
-
+        when(userServiceClient.getFollowerIds(AUTHOR_ID)).thenReturn(List.of(FOLLOWER_1_ID, FOLLOWER_2_ID));
         PostResponseDto out = service.publish(POST_ID);
 
         verify(postMapper, times(1)).toDto(any(Post.class));
+        verify(kafkaPostProducer).publishPostCreate(any(PostEventDto.class));
         assertTrue(out.published());
         assertNotNull(out.publishedAt());
     }

--- a/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
@@ -49,6 +49,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doReturn;
@@ -222,7 +223,16 @@ class PostServiceImplTest {
     void publish_ok() {
         when(postRepository.findById(POST_ID)).thenReturn(Optional.of(postDbEntity));
         when(postRepository.save(any(Post.class))).thenAnswer(inv -> inv.getArgument(0));
-        when(userServiceClient.getFollowerIds(AUTHOR_ID)).thenReturn(List.of(FOLLOWER_1_ID, FOLLOWER_2_ID));
+        when(userServiceClient.getFollowers(
+                eq(AUTHOR_ID),
+                isNull(),
+                isNull(),
+                eq(0),
+                eq(Integer.MAX_VALUE)))
+                .thenReturn(List.of(
+                        new UserDto(FOLLOWER_1_ID, "User1", "user1@mail.com"),
+                        new UserDto(FOLLOWER_2_ID, "User2", "user2@mail.com")
+                ));
         PostResponseDto out = service.publish(POST_ID);
 
         verify(postMapper, times(1)).toDto(any(Post.class));

--- a/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
@@ -17,7 +17,6 @@ import faang.school.postservice.dto.user.UserDto;
 import faang.school.postservice.exception.EntityNotFoundException;
 import faang.school.postservice.mapper.post.PostMapper;
 import faang.school.postservice.model.Post;
-import faang.school.postservice.publisher.KafkaPostProducer;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.scheduler.ThreadPoolConfig;
 import faang.school.postservice.service.PostServiceImpl;
@@ -27,10 +26,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 
 import java.lang.reflect.Field;
@@ -99,7 +100,7 @@ class PostServiceImplTest {
     @Mock
     private UserContext userContext;
     @Mock
-    private KafkaPostProducer kafkaPostProducer;
+    ApplicationEventPublisher eventPublisher;
     @Spy
     private PostMapper postMapper = Mappers.getMapper(PostMapper.class);
     private Post postDbEntity;
@@ -235,10 +236,21 @@ class PostServiceImplTest {
                 ));
         PostResponseDto out = service.publish(POST_ID);
 
-        verify(postMapper, times(1)).toDto(any(Post.class));
-        verify(kafkaPostProducer).publishPostCreate(any(PostEventDto.class));
         assertTrue(out.published());
         assertNotNull(out.publishedAt());
+        verify(postMapper, times(1)).toDto(any(Post.class));
+
+        ArgumentCaptor<PostEventDto> eventCaptor = ArgumentCaptor.forClass(PostEventDto.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+
+        PostEventDto capturedEvent = eventCaptor.getValue();
+        assertEquals(POST_ID, capturedEvent.postId());
+        assertEquals(AUTHOR_ID, capturedEvent.authorId());
+        assertNotNull(capturedEvent.followerIds());
+        assertEquals(2, capturedEvent.followerIds().size());
+        assertTrue(capturedEvent.followerIds().contains(FOLLOWER_1_ID));
+        assertTrue(capturedEvent.followerIds().contains(FOLLOWER_2_ID));
+        assertNotNull(capturedEvent.publishedAt());
     }
 
     @Test


### PR DESCRIPTION
Публикация эвента поста в Kafka 
Задание
1.	Когда пользователь создает пост, то после его сохранения в БД нужно отправить соответствующий эвент в новый Kafka-топик: posts
2.	Для этого создать конфигурацию KafkaTemplate и данного топика, если их еще нет. Подключить зависимость Spring + Kafka, а также добавить соответствующие Docker контейнеры в docker compose в репозитории infra. ВАЖНО: сделать ветку для вашей команды в этом репозитории, если ее еще нет
3.	Далее создать KafkaPostProducer, который будет публиковать JSON эвента о создании поста в данный топик после того, как пост был успешно сохранен в БД
4.	В эвенте должен содержаться список id всех подписчиков автора данного поста. Его, разумеется, получить из БД, написав соответствующий запрос