### PR TITLE
BJS2-97837 News Feed: BJS2-97844 Публикация эвента поста в Kafka

### DIFF
--- a/.github/workflows/ci-prs.yaml
+++ b/.github/workflows/ci-prs.yaml
@@ -2,7 +2,6 @@ name: Check PRs
 
 on:
   pull_request:
-    branches: [ chimera-master-stream12 ]
     types: [ opened, reopened, synchronize, edited ]
 
 permissions:

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -249,7 +249,7 @@
         <module name="NoWhitespaceBeforeCaseDefaultColon"/>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="ConstructorsDeclarationGrouping"/>
-        <module name="VariableDeclarationUsageDistance"/>
+        <!--module name="VariableDeclarationUsageDistance"/-->
         <!--<module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>

--- a/src/main/java/faang/school/postservice/client/UserServiceClient.java
+++ b/src/main/java/faang/school/postservice/client/UserServiceClient.java
@@ -19,4 +19,13 @@ public interface UserServiceClient {
 
     @GetMapping("/users")
     List<UserDto> getUsersByIds(@RequestParam("ids") List<Long> ids);
+
+    @GetMapping("/subscriptions/{followeeId}/followers")
+    List<UserDto> getFollowers(
+            @PathVariable long followeeId,
+            @RequestParam(required = false) String namePattern,
+            @RequestParam(required = false) String phonePattern,
+            @RequestParam(defaultValue = "0") int experienceMin,
+            @RequestParam(defaultValue = "2147483647") int experienceMax
+    );
 }

--- a/src/main/java/faang/school/postservice/dto/post/PostCreatedEventDto.java
+++ b/src/main/java/faang/school/postservice/dto/post/PostCreatedEventDto.java
@@ -17,14 +17,4 @@ public record PostCreatedEventDto(
         List<Long> followerIds,
         int version
 ) {
-    public record Publisher(
-            PublisherType type,
-            long id
-    ) {
-    }
-
-    public enum PublisherType {
-        USER,
-        PROJECT
-    }
 }

--- a/src/main/java/faang/school/postservice/dto/post/PostCreatedEventDto.java
+++ b/src/main/java/faang/school/postservice/dto/post/PostCreatedEventDto.java
@@ -1,0 +1,30 @@
+package faang.school.postservice.dto.post;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PostCreatedEventDto(
+        UUID eventId,
+        Instant occurredAt,
+        long postId,
+        Publisher publisher,
+        List<Long> followerIds,
+        int version
+) {
+    public record Publisher(
+            PublisherType type,
+            long id
+    ) {
+    }
+
+    public enum PublisherType {
+        USER,
+        PROJECT
+    }
+}

--- a/src/main/java/faang/school/postservice/dto/post/Publisher.java
+++ b/src/main/java/faang/school/postservice/dto/post/Publisher.java
@@ -1,0 +1,7 @@
+package faang.school.postservice.dto.post;
+
+public record Publisher(
+        PublisherType type,
+        long id
+) {
+}

--- a/src/main/java/faang/school/postservice/dto/post/PublisherType.java
+++ b/src/main/java/faang/school/postservice/dto/post/PublisherType.java
@@ -1,0 +1,6 @@
+package faang.school.postservice.dto.post;
+
+public enum PublisherType {
+    USER,
+    PROJECT
+}

--- a/src/main/java/faang/school/postservice/model/Post.java
+++ b/src/main/java/faang/school/postservice/model/Post.java
@@ -40,7 +40,7 @@ public class Post {
     @Column(name = "content", nullable = false, length = 4096)
     private String content;
 
-    @Column(name = "author_id", nullable = false)
+    @Column(name = "author_id")
     private Long authorId;
 
     @Column(name = "project_id")

--- a/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaProducer.java
+++ b/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaProducer.java
@@ -22,7 +22,12 @@ public class PostCreatedKafkaProducer {
         kafkaTemplate.send(postCreatedEventTopic, key, event)
                 .whenComplete((res, ex) -> {
                     if (ex != null) {
-                        log.error("Failed to send PostCreatedEvent: postId={}, eventId={}", event.postId(), event.eventId(), ex);
+                        log.error(
+                                "Failed to send PostCreatedEvent: postId={}, eventId={}",
+                                event.postId(),
+                                event.eventId(),
+                                ex
+                        );
                     }
                 });
         log.info("PostCreatedEvent sent to Kafka: postId={}, eventId={}", event.postId(), event.eventId());

--- a/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaProducer.java
+++ b/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaProducer.java
@@ -1,0 +1,30 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostCreatedEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostCreatedKafkaProducer {
+
+    private final KafkaTemplate<String, PostCreatedEventDto> kafkaTemplate;
+
+    @Value("${app.kafka.topics.posts-created-topic:posts-created-topic}")
+    private String postCreatedEventTopic;
+
+    public void send(PostCreatedEventDto event) {
+        String key = String.valueOf(event.postId());
+        kafkaTemplate.send(postCreatedEventTopic, key, event)
+                .whenComplete((res, ex) -> {
+                    if (ex != null) {
+                        log.error("Failed to send PostCreatedEvent: postId={}, eventId={}", event.postId(), event.eventId(), ex);
+                    }
+                });
+        log.info("PostCreatedEvent sent to Kafka: postId={}, eventId={}", event.postId(), event.eventId());
+    }
+}

--- a/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaPublisher.java
+++ b/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaPublisher.java
@@ -1,0 +1,20 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostCreatedEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostCreatedKafkaPublisher {
+    private final PostCreatedKafkaProducer producer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PostCreatedEventDto event) {
+        producer.send(event);
+    }
+}

--- a/src/main/java/faang/school/postservice/service/FollowersService.java
+++ b/src/main/java/faang/school/postservice/service/FollowersService.java
@@ -1,0 +1,7 @@
+package faang.school.postservice.service;
+
+import java.util.List;
+
+public interface FollowersService {
+    List<Long> getFollowerIds(Long authorId);
+}

--- a/src/main/java/faang/school/postservice/service/FollowersServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/FollowersServiceImpl.java
@@ -1,0 +1,55 @@
+package faang.school.postservice.service;
+
+import faang.school.postservice.client.UserServiceClient;
+import faang.school.postservice.dto.user.UserDto;
+import faang.school.postservice.exception.externalservice.ExternalServiceException;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FollowersServiceImpl implements FollowersService {
+    private final UserServiceClient userServiceClient;
+
+    @Retryable(
+            retryFor = FeignException.class,
+            backoff = @Backoff(delay = 500, multiplier = 2.0)
+    )
+    public List<Long> getFollowerIds(Long authorId) {
+        if (authorId == null) {
+            log.warn("AuthorId is null, can't find followers");
+            return Collections.emptyList();
+        }
+
+        try {
+            List<UserDto> followers = userServiceClient.getFollowers(
+                    authorId,
+                    null,
+                    null,
+                    0,
+                    Integer.MAX_VALUE
+            );
+            return followers.stream()
+                    .map(UserDto::id)
+                    .collect(Collectors.toList());
+        } catch (FeignException.NotFound e) {
+            log.warn("User {} not found when getting followers", authorId);
+            return Collections.emptyList();
+        } catch (FeignException e) {
+            log.error("Failed to get followers from user-service for author {}", authorId, e);
+            throw new ExternalServiceException("user_service", "Cannot fetch followers - user-service unavailable", e);
+        } catch (Exception e) {
+            log.error("Unexpected error when searching for followers for an author {}", authorId, e);
+            throw new ExternalServiceException("user_service", "Cannot fetch followers - unexpected error", e);
+        }
+    }
+}

--- a/src/main/java/faang/school/postservice/service/PostServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/PostServiceImpl.java
@@ -6,6 +6,7 @@ import faang.school.postservice.client.UserServiceClient;
 import faang.school.postservice.config.context.LanguageToolConfig;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
 import faang.school.postservice.dto.post.PostCreatedEventDto;
+import faang.school.postservice.dto.post.Publisher;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.post.PostResponseDto;
 import faang.school.postservice.dto.project.ProjectDto;
@@ -40,8 +41,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import static faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.PROJECT;
-import static faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.USER;
+import static faang.school.postservice.dto.post.PublisherType.PROJECT;
+import static faang.school.postservice.dto.post.PublisherType.USER;
 
 @Slf4j
 @Service
@@ -102,7 +103,7 @@ public class PostServiceImpl implements PostService {
         return postMapper.toDto(saved);
     }
 
-    private PostCreatedEventDto.Publisher resolvePublisher(Post post) {
+    private Publisher resolvePublisher(Post post) {
         boolean hasAuthor = post.getAuthorId() != null;
         boolean hasProject = post.getProjectId() != null;
 
@@ -111,9 +112,9 @@ public class PostServiceImpl implements PostService {
         }
 
         if (hasAuthor) {
-            return new PostCreatedEventDto.Publisher(USER, post.getAuthorId());
+            return new Publisher(USER, post.getAuthorId());
         }
-        return new PostCreatedEventDto.Publisher(PROJECT, post.getProjectId());
+        return new Publisher(PROJECT, post.getProjectId());
     }
 
     @Override
@@ -130,7 +131,7 @@ public class PostServiceImpl implements PostService {
             throw new IllegalStateException("Post is already published");
         }
 
-        PostCreatedEventDto.Publisher publisher = resolvePublisher(post);
+        Publisher publisher = resolvePublisher(post);
 
         post.setPublished(true);
         post.setPublishedAt(LocalDateTime.now());
@@ -139,10 +140,10 @@ public class PostServiceImpl implements PostService {
 
         log.info("Post published id={} at {}", id, saved.getPublishedAt());
 
-        List<Long> followerIds = switch (publisher.type()) {
-            case USER -> followersService.getFollowerIds(publisher.id());
-            case PROJECT -> List.of(); // not created yet, so no followers
-        };
+        List<Long> followerIds =
+                publisher.type() == USER
+                        ? followersService.getFollowerIds(publisher.id())
+                        : List.of(); // not created yet, so no followers
 
         PostCreatedEventDto event = new PostCreatedEventDto(
                 UUID.randomUUID(),

--- a/src/main/java/faang/school/postservice/service/PostServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/PostServiceImpl.java
@@ -4,8 +4,8 @@ import faang.school.postservice.client.ProjectServiceClient;
 import faang.school.postservice.client.FeignLanguageToolClient;
 import faang.school.postservice.client.UserServiceClient;
 import faang.school.postservice.config.context.LanguageToolConfig;
-import faang.school.postservice.config.context.UserContext;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
+import faang.school.postservice.dto.post.PostCreatedEventDto;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.post.PostResponseDto;
 import faang.school.postservice.dto.project.ProjectDto;
@@ -23,6 +23,7 @@ import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
@@ -30,12 +31,17 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+
+import static faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.PROJECT;
+import static faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.USER;
 
 @Slf4j
 @Service
@@ -48,12 +54,10 @@ public class PostServiceImpl implements PostService {
     private final UserServiceClient userServiceClient;
     private final ProjectServiceClient projectServiceClient;
     private final LanguageToolConfig languageToolConfig;
-    private static final long SECOND_DELAY_MS = 3000L;
-    private static final long THIRD_DELAY_MS = 4000L;
-    private static final long FOURTH_DELAY_MS = 5000L;
     private final FeignLanguageToolClient feignLanguageTool;
-    private final UserContext userContext;
     private final ThreadPoolConfig threadPoolConfig;
+    private final FollowersService followersService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Value("${scheduler.thread-pool.batchSize:50}")
     private int batchSize;
@@ -98,6 +102,20 @@ public class PostServiceImpl implements PostService {
         return postMapper.toDto(saved);
     }
 
+    private PostCreatedEventDto.Publisher resolvePublisher(Post post) {
+        boolean hasAuthor = post.getAuthorId() != null;
+        boolean hasProject = post.getProjectId() != null;
+
+        if (hasAuthor == hasProject) { // оба true или оба false
+            throw new IllegalStateException("Post must have exactly one publisher: authorId XOR projectId");
+        }
+
+        if (hasAuthor) {
+            return new PostCreatedEventDto.Publisher(USER, post.getAuthorId());
+        }
+        return new PostCreatedEventDto.Publisher(PROJECT, post.getProjectId());
+    }
+
     @Override
     public PostResponseDto publish(long id) {
         log.info("Publishing post id={}", id);
@@ -112,12 +130,34 @@ public class PostServiceImpl implements PostService {
             throw new IllegalStateException("Post is already published");
         }
 
+        PostCreatedEventDto.Publisher publisher = resolvePublisher(post);
+
         post.setPublished(true);
         post.setPublishedAt(LocalDateTime.now());
         post.setUpdatedAt(LocalDateTime.now());
         Post saved = postRepository.save(post);
 
         log.info("Post published id={} at {}", id, saved.getPublishedAt());
+
+        List<Long> followerIds = switch (publisher.type()) {
+            case USER -> followersService.getFollowerIds(publisher.id());
+            case PROJECT -> List.of(); // not created yet, so no followers
+        };
+
+        PostCreatedEventDto event = new PostCreatedEventDto(
+                UUID.randomUUID(),
+                Instant.now(),
+                saved.getId(),
+                publisher,
+                followerIds,
+                1
+        );
+
+        applicationEventPublisher.publishEvent(event);
+
+        log.info("Post published id={} and event queued (publisherType={}, publisherId={}, followersCount={})",
+                saved.getId(), publisher.type(), publisher.id(), followerIds.size());
+
         return postMapper.toDto(saved);
     }
 
@@ -227,7 +267,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    @Retryable(retryFor = {FeignException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 2))
+    @Retryable(retryFor = {FeignException.class}, backoff = @Backoff(delay = 1000, multiplier = 2))
     public void processTextChecking() {
         List<Post> unpublishedPosts = postRepository.findReadyToPublish();
         log.info("Found {} posts for text correction", unpublishedPosts.size());
@@ -268,7 +308,7 @@ public class PostServiceImpl implements PostService {
 
         List<MatchDto> sortedMatches = response.matches().stream()
                 .sorted((m1, m2) -> Integer.compare(m2.offset(), m1.offset()))
-                .collect(Collectors.toList());
+                .toList();
 
         StringBuilder correctedText = new StringBuilder(originalText);
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -91,6 +91,9 @@ services:
     bucketName: corpbucket
 
 app:
+  kafka:
+    topics:
+      posts-created-topic: posts-created-topic
   resources:
     image:
       max-file-size-mb: 5

--- a/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
@@ -8,6 +8,7 @@ import faang.school.postservice.config.context.UserContext;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
 import faang.school.postservice.dto.post.PostCreatedEventDto;
 import faang.school.postservice.dto.post.PostResponseDto;
+import faang.school.postservice.dto.post.PublisherType;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.project.ProjectDto;
 import faang.school.postservice.dto.text.MatchDto;
@@ -668,7 +669,7 @@ class PostServiceImplTest {
         assertNotNull(event.occurredAt());
         assertEquals(POST_ID, event.postId());
         assertEquals(followerIds, event.followerIds());
-        assertEquals(faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.USER, event.publisher().type());
+        assertEquals(PublisherType.USER, event.publisher().type());
         assertEquals(AUTHOR_ID, event.publisher().id());
         assertEquals(1, event.version());
     }
@@ -686,15 +687,15 @@ class PostServiceImplTest {
 
         verify(followersService, never()).getFollowerIds(any());
 
-        ArgumentCaptor<faang.school.postservice.dto.post.PostCreatedEventDto> captor =
-                ArgumentCaptor.forClass(faang.school.postservice.dto.post.PostCreatedEventDto.class);
+        ArgumentCaptor<PostCreatedEventDto> captor =
+                ArgumentCaptor.forClass(PostCreatedEventDto.class);
 
         verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
 
         var event = captor.getValue();
         assertEquals(POST_ID, event.postId());
         assertTrue(event.followerIds().isEmpty());
-        assertEquals(faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.PROJECT, event.publisher().type());
+        assertEquals(PublisherType.PROJECT, event.publisher().type());
         assertEquals(PROJECT_ID, event.publisher().id());
     }
 

--- a/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
@@ -6,6 +6,7 @@ import faang.school.postservice.client.UserServiceClient;
 import faang.school.postservice.config.context.LanguageToolConfig;
 import faang.school.postservice.config.context.UserContext;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
+import faang.school.postservice.dto.post.PostCreatedEventDto;
 import faang.school.postservice.dto.post.PostResponseDto;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.project.ProjectDto;
@@ -18,6 +19,7 @@ import faang.school.postservice.mapper.post.PostMapper;
 import faang.school.postservice.model.Post;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.scheduler.ThreadPoolConfig;
+import faang.school.postservice.service.FollowersService;
 import faang.school.postservice.service.PostServiceImpl;
 import feign.FeignException;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 
 import java.lang.reflect.Field;
@@ -55,6 +58,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import org.mockito.ArgumentCaptor;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceImplTest {
@@ -92,6 +97,10 @@ class PostServiceImplTest {
     private FeignLanguageToolClient feignLanguageTool;
     @Mock
     private UserContext userContext;
+    @Mock
+    FollowersService followersService;
+    @Mock
+    ApplicationEventPublisher applicationEventPublisher;
     @Spy
     private PostMapper postMapper = Mappers.getMapper(PostMapper.class);
     private Post postDbEntity;
@@ -632,4 +641,101 @@ class PostServiceImplTest {
         assertDoesNotThrow(() -> service.processTextChecking());
         verify(postRepository, never()).save(any(Post.class));
     }
+
+    @Test
+    @DisplayName("publish: USER publisher -> loads followerIds and publishes Spring event")
+    void publish_user_publishesEvent_withFollowers() {
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(postDbEntity));
+        when(postRepository.save(any(Post.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Long> followerIds = List.of(101L, 102L, 103L);
+        when(followersService.getFollowerIds(AUTHOR_ID)).thenReturn(followerIds);
+
+        PostResponseDto out = service.publish(POST_ID);
+
+        assertTrue(out.published());
+        assertNotNull(out.publishedAt());
+
+        verify(followersService, times(1)).getFollowerIds(AUTHOR_ID);
+
+        ArgumentCaptor<PostCreatedEventDto> captor =
+                ArgumentCaptor.forClass(PostCreatedEventDto.class);
+
+        verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
+
+        var event = captor.getValue();
+        assertNotNull(event.eventId());
+        assertNotNull(event.occurredAt());
+        assertEquals(POST_ID, event.postId());
+        assertEquals(followerIds, event.followerIds());
+        assertEquals(faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.USER, event.publisher().type());
+        assertEquals(AUTHOR_ID, event.publisher().id());
+        assertEquals(1, event.version());
+    }
+
+    @Test
+    @DisplayName("publish: PROJECT publisher -> does not load followers, publishes event with empty followerIds")
+    void publish_project_publishesEvent_withoutFollowersCall() {
+        Post projectPost = buildPost(POST_ID, null, PROJECT_ID, CONTENT, false, false,
+                LocalDateTime.now().minusHours(1), null);
+
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(projectPost));
+        when(postRepository.save(any(Post.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.publish(POST_ID);
+
+        verify(followersService, never()).getFollowerIds(any());
+
+        ArgumentCaptor<faang.school.postservice.dto.post.PostCreatedEventDto> captor =
+                ArgumentCaptor.forClass(faang.school.postservice.dto.post.PostCreatedEventDto.class);
+
+        verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
+
+        var event = captor.getValue();
+        assertEquals(POST_ID, event.postId());
+        assertTrue(event.followerIds().isEmpty());
+        assertEquals(faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.PROJECT, event.publisher().type());
+        assertEquals(PROJECT_ID, event.publisher().id());
+    }
+
+    @Test
+    @DisplayName("publish: invalid publisher (both authorId and projectId) -> throws")
+    void publish_bothPublishers_throws() {
+        Post invalid = buildPost(POST_ID, AUTHOR_ID, PROJECT_ID, CONTENT, false, false,
+                LocalDateTime.now().minusHours(1), null);
+
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(invalid));
+
+        assertThrows(IllegalStateException.class, () -> service.publish(POST_ID));
+
+        verify(postRepository, never()).save(any());
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("publish: invalid publisher (no authorId and no projectId) -> throws")
+    void publish_noPublisher_throws() {
+        Post invalid = buildPost(POST_ID, null, null, CONTENT, false, false,
+                LocalDateTime.now().minusHours(1), null);
+
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(invalid));
+
+        assertThrows(IllegalStateException.class, () -> service.publish(POST_ID));
+
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("publish: followersService fails -> event not published")
+    void publish_followersServiceFails_eventNotPublished() {
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(postDbEntity));
+        when(postRepository.save(any(Post.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        when(followersService.getFollowerIds(AUTHOR_ID)).thenThrow(new RuntimeException("user-service down"));
+
+        assertThrows(RuntimeException.class, () -> service.publish(POST_ID));
+
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
 }


### PR DESCRIPTION
Публикация эвента поста в Kafka


Задание
Когда пользователь создает пост, то после его сохранения в БД нужно отправить соответствующий эвент в новый Kafka-топик: posts

Для этого создать конфигурацию KafkaTemplate и данного топика, если их еще нет. Подключить зависимость Spring + Kafka, а также добавить соответствующие Docker контейнеры в docker compose в репозитории infra. ВАЖНО: сделать ветку для вашей команды в этом репозитории, если ее еще нет

Далее создать KafkaPostProducer, который будет публиковать JSON эвента о создании поста в данный топик после того, как пост был успешно сохранен в БД

В эвенте должен содержаться список id всех подписчиков автора данного поста. Его, разумеется, получить из БД, написав соответствующий запрос


<img width="2736" height="1816" alt="image" src="https://github.com/user-attachments/assets/fe8b94fa-282c-4f55-be1f-bc6833e0e070" />
