### PR TITLE
Feature bjs2 97837 news feed 2 bjs2 97848 kafka post event listener

### DIFF
--- a/.github/workflows/ci-prs.yaml
+++ b/.github/workflows/ci-prs.yaml
@@ -2,7 +2,6 @@ name: Check PRs
 
 on:
   pull_request:
-    branches: [ chimera-master-stream12 ]
     types: [ opened, reopened, synchronize, edited ]
 
 permissions:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
     id("checkstyle")
     id("org.jsonschema2pojo") version "1.2.1"
     id("jacoco")
+    kotlin("jvm")
 }
 
 group = "faang.school"
 version = "1.0"
-java.sourceCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -84,6 +84,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.24.2")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.kafka:spring-kafka-test")
+    implementation(kotlin("stdlib-jdk8"))
 }
 
 configure<JacocoPluginExtension> {
@@ -198,4 +199,7 @@ tasks.jacocoTestReport {
             }
         }
     )
+}
+kotlin {
+    jvmToolchain(17)
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -249,7 +249,7 @@
         <module name="NoWhitespaceBeforeCaseDefaultColon"/>
         <module name="OverloadMethodsDeclarationOrder"/>
         <module name="ConstructorsDeclarationGrouping"/>
-        <module name="VariableDeclarationUsageDistance"/>
+        <!--module name="VariableDeclarationUsageDistance"/-->
         <!--<module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,1 +1,9 @@
+pluginManagement {
+    plugins {
+        kotlin("jvm") version "2.0.21"
+    }
+}
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+}
 rootProject.name = "PostService"

--- a/src/main/java/faang/school/postservice/PostServiceApp.java
+++ b/src/main/java/faang/school/postservice/PostServiceApp.java
@@ -1,12 +1,15 @@
 package faang.school.postservice;
 
+import faang.school.postservice.config.FeedRedisProperties;
 import org.springframework.boot.Banner;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableConfigurationProperties(FeedRedisProperties.class)
 @SpringBootApplication
 @EnableScheduling
 @EnableFeignClients(basePackages = "faang.school.postservice.client")

--- a/src/main/java/faang/school/postservice/client/UserServiceClient.java
+++ b/src/main/java/faang/school/postservice/client/UserServiceClient.java
@@ -19,4 +19,13 @@ public interface UserServiceClient {
 
     @GetMapping("/users")
     List<UserDto> getUsersByIds(@RequestParam("ids") List<Long> ids);
+
+    @GetMapping("/subscriptions/{followeeId}/followers")
+    List<UserDto> getFollowers(
+            @PathVariable long followeeId,
+            @RequestParam(required = false) String namePattern,
+            @RequestParam(required = false) String phonePattern,
+            @RequestParam(defaultValue = "0") int experienceMin,
+            @RequestParam(defaultValue = "2147483647") int experienceMax
+    );
 }

--- a/src/main/java/faang/school/postservice/config/FeedRedisProperties.java
+++ b/src/main/java/faang/school/postservice/config/FeedRedisProperties.java
@@ -1,0 +1,11 @@
+package faang.school.postservice.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties(prefix = "app.feed.redis")
+public class FeedRedisProperties {
+    private int maxSize = 500;
+    private String keyPrefix = "feed:v1:";
+}

--- a/src/main/java/faang/school/postservice/dto/post/PostCreatedEventDto.java
+++ b/src/main/java/faang/school/postservice/dto/post/PostCreatedEventDto.java
@@ -17,14 +17,4 @@ public record PostCreatedEventDto(
         List<Long> followerIds,
         int version
 ) {
-    public record Publisher(
-            PublisherType type,
-            long id
-    ) {
-    }
-
-    public enum PublisherType {
-        USER,
-        PROJECT
-    }
 }

--- a/src/main/java/faang/school/postservice/dto/post/PostCreatedEventDto.java
+++ b/src/main/java/faang/school/postservice/dto/post/PostCreatedEventDto.java
@@ -1,0 +1,30 @@
+package faang.school.postservice.dto.post;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record PostCreatedEventDto(
+        UUID eventId,
+        Instant occurredAt,
+        long postId,
+        Publisher publisher,
+        List<Long> followerIds,
+        int version
+) {
+    public record Publisher(
+            PublisherType type,
+            long id
+    ) {
+    }
+
+    public enum PublisherType {
+        USER,
+        PROJECT
+    }
+}

--- a/src/main/java/faang/school/postservice/dto/post/Publisher.java
+++ b/src/main/java/faang/school/postservice/dto/post/Publisher.java
@@ -1,0 +1,7 @@
+package faang.school.postservice.dto.post;
+
+public record Publisher(
+        PublisherType type,
+        long id
+) {
+}

--- a/src/main/java/faang/school/postservice/dto/post/PublisherType.java
+++ b/src/main/java/faang/school/postservice/dto/post/PublisherType.java
@@ -1,0 +1,6 @@
+package faang.school.postservice.dto.post;
+
+public enum PublisherType {
+    USER,
+    PROJECT
+}

--- a/src/main/java/faang/school/postservice/model/Post.java
+++ b/src/main/java/faang/school/postservice/model/Post.java
@@ -40,7 +40,7 @@ public class Post {
     @Column(name = "content", nullable = false, length = 4096)
     private String content;
 
-    @Column(name = "author_id", nullable = false)
+    @Column(name = "author_id")
     private Long authorId;
 
     @Column(name = "project_id")

--- a/src/main/java/faang/school/postservice/publisher/KafkaPostConsumer.java
+++ b/src/main/java/faang/school/postservice/publisher/KafkaPostConsumer.java
@@ -1,0 +1,57 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostCreatedEventDto;
+import faang.school.postservice.service.FeedService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaPostConsumer {
+
+    private final FeedService feedService;
+
+    @KafkaListener(
+            topics = "${app.kafka.topics.posts-created-topic}",
+            groupId = "${spring.kafka.consumer.group-id}"
+    )
+    public void onPostCreated(
+            PostCreatedEventDto event,
+            Acknowledgment ack
+    ) {
+        log.info(
+                "Received PostCreatedEvent: postId={}, followers={}",
+                event.postId(),
+                event.followerIds().size()
+        );
+
+        try {
+            event.followerIds().forEach(
+                    followerId -> feedService.addPostToFeed
+                            (
+                                    followerId,
+                                    event.postId(),
+                                    event.occurredAt()
+                            ));
+
+            ack.acknowledge();
+
+            log.info(
+                    "Post {} added to {} feeds, ack sent",
+                    event.postId(),
+                    event.followerIds().size()
+            );
+        } catch (Exception e) {
+            log.error(
+                    "Failed to process PostCreatedEvent postId={}",
+                    event.postId(),
+                    e
+            );
+            throw e;
+        }
+    }
+}

--- a/src/main/java/faang/school/postservice/publisher/KafkaPostConsumer.java
+++ b/src/main/java/faang/school/postservice/publisher/KafkaPostConsumer.java
@@ -31,12 +31,11 @@ public class KafkaPostConsumer {
 
         try {
             event.followerIds().forEach(
-                    followerId -> feedService.addPostToFeed
-                            (
-                                    followerId,
-                                    event.postId(),
-                                    event.occurredAt()
-                            ));
+                    followerId -> feedService.addPostToFeed(
+                            followerId,
+                            event.postId(),
+                            event.occurredAt()
+                    ));
 
             ack.acknowledge();
 

--- a/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaProducer.java
+++ b/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaProducer.java
@@ -22,7 +22,12 @@ public class PostCreatedKafkaProducer {
         kafkaTemplate.send(postCreatedEventTopic, key, event)
                 .whenComplete((res, ex) -> {
                     if (ex != null) {
-                        log.error("Failed to send PostCreatedEvent: postId={}, eventId={}", event.postId(), event.eventId(), ex);
+                        log.error(
+                                "Failed to send PostCreatedEvent: postId={}, eventId={}",
+                                event.postId(),
+                                event.eventId(),
+                                ex
+                        );
                     }
                 });
         log.info("PostCreatedEvent sent to Kafka: postId={}, eventId={}", event.postId(), event.eventId());

--- a/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaProducer.java
+++ b/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaProducer.java
@@ -1,0 +1,30 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostCreatedEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class PostCreatedKafkaProducer {
+
+    private final KafkaTemplate<String, PostCreatedEventDto> kafkaTemplate;
+
+    @Value("${app.kafka.topics.posts-created-topic:posts-created-topic}")
+    private String postCreatedEventTopic;
+
+    public void send(PostCreatedEventDto event) {
+        String key = String.valueOf(event.postId());
+        kafkaTemplate.send(postCreatedEventTopic, key, event)
+                .whenComplete((res, ex) -> {
+                    if (ex != null) {
+                        log.error("Failed to send PostCreatedEvent: postId={}, eventId={}", event.postId(), event.eventId(), ex);
+                    }
+                });
+        log.info("PostCreatedEvent sent to Kafka: postId={}, eventId={}", event.postId(), event.eventId());
+    }
+}

--- a/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaPublisher.java
+++ b/src/main/java/faang/school/postservice/publisher/PostCreatedKafkaPublisher.java
@@ -1,0 +1,20 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostCreatedEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PostCreatedKafkaPublisher {
+    private final PostCreatedKafkaProducer producer;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(PostCreatedEventDto event) {
+        producer.send(event);
+    }
+}

--- a/src/main/java/faang/school/postservice/service/FeedService.java
+++ b/src/main/java/faang/school/postservice/service/FeedService.java
@@ -1,0 +1,55 @@
+package faang.school.postservice.service;
+
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Service responsible for managing user news feeds.
+ *
+ * <p>Feed data is stored in Redis using a {@code ZSET} structure:
+ * <ul>
+ *     <li><b>Key</b>: {@code feed:v1:{followerId}}</li>
+ *     <li><b>Member</b>: {@code postId}</li>
+ *     <li><b>Score</b>: post creation timestamp ({@link Instant})</li>
+ * </ul>
+ *
+ * <p>Redis is used as a fast-access cache layer for feeds.
+ * Only post identifiers are stored here; full post content
+ * is fetched from the database or another service when needed.
+ *
+ * <p>The feed has a fixed maximum size (e.g. 500 posts).
+ * When the limit is exceeded, the oldest posts are removed.
+ */
+@Service
+public interface FeedService {
+
+    /**
+     * Adds a post to a follower's feed.
+     *
+     * <p>The operation is idempotent: if the same post is processed
+     * multiple times (e.g. due to Kafka redelivery), it will not be duplicated
+     * in the feed.
+     *
+     * <p>Posts are ordered by creation time, with the newest posts
+     * appearing at the top of the feed.
+     *
+     * @param followerId id of the user whose feed is being updated
+     * @param postId id of the newly published post
+     * @param occurredAt timestamp when the post was created/published
+     */
+    void addPostToFeed(long followerId, long postId, Instant occurredAt);
+
+    /**
+     * Returns the most recent posts from a follower's feed.
+     *
+     * <p>Posts are returned in reverse chronological order
+     * (newest first).
+     *
+     * @param followerId id of the user whose feed is requested
+     * @param limit maximum number of posts to return
+     * @return list of post ids ordered from newest to oldest
+     */
+    List<Long> getLatestPosts(long followerId, int limit);
+}

--- a/src/main/java/faang/school/postservice/service/FeedServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/FeedServiceImpl.java
@@ -1,0 +1,95 @@
+package faang.school.postservice.service;
+
+import java.time.Instant;
+
+import faang.school.postservice.config.FeedRedisProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FeedServiceImpl implements FeedService {
+
+    /*  Lua script for Redis, to provide ACID transaction as much as possible
+        -- KEYS[1] = feed key
+        -- ARGV[1] = score
+        -- ARGV[2] = member (postId)
+        -- ARGV[3] = maxSize
+        return 1 if post added and 0 in case of duplicate
+     */
+    private static final DefaultRedisScript<Long> ADD_AND_TRIM_SCRIPT;
+
+    static {
+        ADD_AND_TRIM_SCRIPT = new DefaultRedisScript<>();
+        ADD_AND_TRIM_SCRIPT.setResultType(Long.class);
+        ADD_AND_TRIM_SCRIPT.setScriptText(
+                "local added = redis.call('ZADD', KEYS[1], 'NX', ARGV[1], ARGV[2]) " +
+                        "local size = redis.call('ZCARD', KEYS[1]) " +
+                        "local maxSize = tonumber(ARGV[3]) " +
+                        "if size > maxSize then " +
+                        "  local extra = size - maxSize " +
+                        "  redis.call('ZREMRANGEBYRANK', KEYS[1], 0, extra - 1) " +
+                        "end " +
+                        "return added"
+        );
+    }
+
+    private final StringRedisTemplate redis;
+    private final FeedRedisProperties props;
+
+    @Override
+    public void addPostToFeed(long followerId, long postId, Instant occurredAt) {
+        String key = buildKey(followerId);
+
+        // in case of close occurredAt time, we add uniqueness with postId
+        long score = occurredAt.toEpochMilli() * 1_000 + (postId % 1_000);
+
+        Long added = redis.execute(
+                ADD_AND_TRIM_SCRIPT,
+                List.of(key),
+                String.valueOf(score),
+                String.valueOf(postId),
+                String.valueOf(props.getMaxSize())
+        );
+
+        if (added == 1) {
+            log.debug(
+                    "Post added to feed: followerId={}, postId={}, score={}, maxSize={}, key={}",
+                    followerId,
+                    postId,
+                    score,
+                    props.getMaxSize(),
+                    key
+            );
+        } else {
+            log.debug(
+                    "Duplicate PostCreatedEvent ignored: followerId={}, postId={}, key={}",
+                    followerId,
+                    postId,
+                    key
+            );
+        }
+    }
+
+    @Override
+    public List<Long> getLatestPosts(long followerId, int limit) {
+        String key = buildKey(followerId);
+
+        var range = redis.opsForZSet().reverseRange(key, 0, limit - 1);
+        if (range == null || range.isEmpty()) {
+            return List.of();
+        }
+
+        return range.stream().map(Long::parseLong).toList();
+    }
+
+    private String buildKey(long followerId) {
+        return props.getKeyPrefix() + followerId;
+    }
+}

--- a/src/main/java/faang/school/postservice/service/FeedServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/FeedServiceImpl.java
@@ -29,14 +29,14 @@ public class FeedServiceImpl implements FeedService {
         ADD_AND_TRIM_SCRIPT = new DefaultRedisScript<>();
         ADD_AND_TRIM_SCRIPT.setResultType(Long.class);
         ADD_AND_TRIM_SCRIPT.setScriptText(
-                "local added = redis.call('ZADD', KEYS[1], 'NX', ARGV[1], ARGV[2]) " +
-                        "local size = redis.call('ZCARD', KEYS[1]) " +
-                        "local maxSize = tonumber(ARGV[3]) " +
-                        "if size > maxSize then " +
-                        "  local extra = size - maxSize " +
-                        "  redis.call('ZREMRANGEBYRANK', KEYS[1], 0, extra - 1) " +
-                        "end " +
-                        "return added"
+                "local added = redis.call('ZADD', KEYS[1], 'NX', ARGV[1], ARGV[2]) "
+                        + "local size = redis.call('ZCARD', KEYS[1]) "
+                        + "local maxSize = tonumber(ARGV[3]) "
+                        + "if size > maxSize then "
+                        + "  local extra = size - maxSize "
+                        + "  redis.call('ZREMRANGEBYRANK', KEYS[1], 0, extra - 1) "
+                        + "end "
+                        + "return added"
         );
     }
 

--- a/src/main/java/faang/school/postservice/service/FollowersService.java
+++ b/src/main/java/faang/school/postservice/service/FollowersService.java
@@ -1,0 +1,7 @@
+package faang.school.postservice.service;
+
+import java.util.List;
+
+public interface FollowersService {
+    List<Long> getFollowerIds(Long authorId);
+}

--- a/src/main/java/faang/school/postservice/service/FollowersServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/FollowersServiceImpl.java
@@ -1,0 +1,55 @@
+package faang.school.postservice.service;
+
+import faang.school.postservice.client.UserServiceClient;
+import faang.school.postservice.dto.user.UserDto;
+import faang.school.postservice.exception.externalservice.ExternalServiceException;
+import feign.FeignException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FollowersServiceImpl implements FollowersService {
+    private final UserServiceClient userServiceClient;
+
+    @Retryable(
+            retryFor = FeignException.class,
+            backoff = @Backoff(delay = 500, multiplier = 2.0)
+    )
+    public List<Long> getFollowerIds(Long authorId) {
+        if (authorId == null) {
+            log.warn("AuthorId is null, can't find followers");
+            return Collections.emptyList();
+        }
+
+        try {
+            List<UserDto> followers = userServiceClient.getFollowers(
+                    authorId,
+                    null,
+                    null,
+                    0,
+                    Integer.MAX_VALUE
+            );
+            return followers.stream()
+                    .map(UserDto::id)
+                    .collect(Collectors.toList());
+        } catch (FeignException.NotFound e) {
+            log.warn("User {} not found when getting followers", authorId);
+            return Collections.emptyList();
+        } catch (FeignException e) {
+            log.error("Failed to get followers from user-service for author {}", authorId, e);
+            throw new ExternalServiceException("user_service", "Cannot fetch followers - user-service unavailable", e);
+        } catch (Exception e) {
+            log.error("Unexpected error when searching for followers for an author {}", authorId, e);
+            throw new ExternalServiceException("user_service", "Cannot fetch followers - unexpected error", e);
+        }
+    }
+}

--- a/src/main/java/faang/school/postservice/service/PostServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/PostServiceImpl.java
@@ -6,6 +6,7 @@ import faang.school.postservice.client.UserServiceClient;
 import faang.school.postservice.config.context.LanguageToolConfig;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
 import faang.school.postservice.dto.post.PostCreatedEventDto;
+import faang.school.postservice.dto.post.Publisher;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.post.PostResponseDto;
 import faang.school.postservice.dto.project.ProjectDto;
@@ -40,8 +41,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-import static faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.PROJECT;
-import static faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.USER;
+import static faang.school.postservice.dto.post.PublisherType.PROJECT;
+import static faang.school.postservice.dto.post.PublisherType.USER;
 
 @Slf4j
 @Service
@@ -102,7 +103,7 @@ public class PostServiceImpl implements PostService {
         return postMapper.toDto(saved);
     }
 
-    private PostCreatedEventDto.Publisher resolvePublisher(Post post) {
+    private Publisher resolvePublisher(Post post) {
         boolean hasAuthor = post.getAuthorId() != null;
         boolean hasProject = post.getProjectId() != null;
 
@@ -111,9 +112,9 @@ public class PostServiceImpl implements PostService {
         }
 
         if (hasAuthor) {
-            return new PostCreatedEventDto.Publisher(USER, post.getAuthorId());
+            return new Publisher(USER, post.getAuthorId());
         }
-        return new PostCreatedEventDto.Publisher(PROJECT, post.getProjectId());
+        return new Publisher(PROJECT, post.getProjectId());
     }
 
     @Override
@@ -130,7 +131,7 @@ public class PostServiceImpl implements PostService {
             throw new IllegalStateException("Post is already published");
         }
 
-        PostCreatedEventDto.Publisher publisher = resolvePublisher(post);
+        Publisher publisher = resolvePublisher(post);
 
         post.setPublished(true);
         post.setPublishedAt(LocalDateTime.now());
@@ -139,10 +140,10 @@ public class PostServiceImpl implements PostService {
 
         log.info("Post published id={} at {}", id, saved.getPublishedAt());
 
-        List<Long> followerIds = switch (publisher.type()) {
-            case USER -> followersService.getFollowerIds(publisher.id());
-            case PROJECT -> List.of(); // not created yet, so no followers
-        };
+        List<Long> followerIds =
+                publisher.type() == USER
+                        ? followersService.getFollowerIds(publisher.id())
+                        : List.of(); // not created yet, so no followers
 
         PostCreatedEventDto event = new PostCreatedEventDto(
                 UUID.randomUUID(),

--- a/src/main/java/faang/school/postservice/service/PostServiceImpl.java
+++ b/src/main/java/faang/school/postservice/service/PostServiceImpl.java
@@ -4,8 +4,8 @@ import faang.school.postservice.client.ProjectServiceClient;
 import faang.school.postservice.client.FeignLanguageToolClient;
 import faang.school.postservice.client.UserServiceClient;
 import faang.school.postservice.config.context.LanguageToolConfig;
-import faang.school.postservice.config.context.UserContext;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
+import faang.school.postservice.dto.post.PostCreatedEventDto;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.post.PostResponseDto;
 import faang.school.postservice.dto.project.ProjectDto;
@@ -23,6 +23,7 @@ import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.retry.annotation.Backoff;
@@ -30,12 +31,17 @@ import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
+
+import static faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.PROJECT;
+import static faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.USER;
 
 @Slf4j
 @Service
@@ -48,12 +54,10 @@ public class PostServiceImpl implements PostService {
     private final UserServiceClient userServiceClient;
     private final ProjectServiceClient projectServiceClient;
     private final LanguageToolConfig languageToolConfig;
-    private static final long SECOND_DELAY_MS = 3000L;
-    private static final long THIRD_DELAY_MS = 4000L;
-    private static final long FOURTH_DELAY_MS = 5000L;
     private final FeignLanguageToolClient feignLanguageTool;
-    private final UserContext userContext;
     private final ThreadPoolConfig threadPoolConfig;
+    private final FollowersService followersService;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Value("${scheduler.thread-pool.batchSize:50}")
     private int batchSize;
@@ -98,6 +102,20 @@ public class PostServiceImpl implements PostService {
         return postMapper.toDto(saved);
     }
 
+    private PostCreatedEventDto.Publisher resolvePublisher(Post post) {
+        boolean hasAuthor = post.getAuthorId() != null;
+        boolean hasProject = post.getProjectId() != null;
+
+        if (hasAuthor == hasProject) { // оба true или оба false
+            throw new IllegalStateException("Post must have exactly one publisher: authorId XOR projectId");
+        }
+
+        if (hasAuthor) {
+            return new PostCreatedEventDto.Publisher(USER, post.getAuthorId());
+        }
+        return new PostCreatedEventDto.Publisher(PROJECT, post.getProjectId());
+    }
+
     @Override
     public PostResponseDto publish(long id) {
         log.info("Publishing post id={}", id);
@@ -112,12 +130,34 @@ public class PostServiceImpl implements PostService {
             throw new IllegalStateException("Post is already published");
         }
 
+        PostCreatedEventDto.Publisher publisher = resolvePublisher(post);
+
         post.setPublished(true);
         post.setPublishedAt(LocalDateTime.now());
         post.setUpdatedAt(LocalDateTime.now());
         Post saved = postRepository.save(post);
 
         log.info("Post published id={} at {}", id, saved.getPublishedAt());
+
+        List<Long> followerIds = switch (publisher.type()) {
+            case USER -> followersService.getFollowerIds(publisher.id());
+            case PROJECT -> List.of(); // not created yet, so no followers
+        };
+
+        PostCreatedEventDto event = new PostCreatedEventDto(
+                UUID.randomUUID(),
+                Instant.now(),
+                saved.getId(),
+                publisher,
+                followerIds,
+                1
+        );
+
+        applicationEventPublisher.publishEvent(event);
+
+        log.info("Post published id={} and event queued (publisherType={}, publisherId={}, followersCount={})",
+                saved.getId(), publisher.type(), publisher.id(), followerIds.size());
+
         return postMapper.toDto(saved);
     }
 
@@ -227,7 +267,7 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    @Retryable(retryFor = {FeignException.class}, maxAttempts = 3, backoff = @Backoff(delay = 1000, multiplier = 2))
+    @Retryable(retryFor = {FeignException.class}, backoff = @Backoff(delay = 1000, multiplier = 2))
     public void processTextChecking() {
         List<Post> unpublishedPosts = postRepository.findReadyToPublish();
         log.info("Found {} posts for text correction", unpublishedPosts.size());
@@ -268,7 +308,7 @@ public class PostServiceImpl implements PostService {
 
         List<MatchDto> sortedMatches = response.matches().stream()
                 .sorted((m1, m2) -> Integer.compare(m2.offset(), m1.offset()))
-                .collect(Collectors.toList());
+                .toList();
 
         StringBuilder correctedText = new StringBuilder(originalText);
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -9,7 +9,25 @@ spring:
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
       acks: all
       properties:
-        spring.json.add.type.headers: false
+        spring.json.add.type.headers: true
+        spring.json.type.mapping: postCreated:faang.school.postservice.dto.post.PostCreatedEventDto
+
+    consumer:
+      group-id: post-service-feed
+      enable-auto-commit: false
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.use.type.headers: true
+        spring.json.trusted.packages: "faang.school.postservice.dto.post"
+        spring.json.value.default.type: faang.school.postservice.dto.post.PostCreatedEventDto
+        spring.json.type.mapping: postCreated:faang.school.postservice.dto.post.PostCreatedEventDto
+
+    listener:
+      ack-mode: manual
+      # чтобы не прилетали пачки сообщений при ручном ack (обычно в учебных проектах так проще)
+      type: single
 
   servlet:
     multipart:
@@ -99,6 +117,10 @@ app:
       max-file-size-mb: 5
       max-per-post: 10
       type: "IMAGE"
+  feed:
+    redis:
+      max-size: 500
+      key-prefix: "feed:v1:"
 
 post-correcter:
   cron: "0 0 3 * * *" # every day at 3:00

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -91,6 +91,9 @@ services:
     bucketName: corpbucket
 
 app:
+  kafka:
+    topics:
+      posts-created-topic: posts-created-topic
   resources:
     image:
       max-file-size-mb: 5

--- a/src/test/java/faang/school/postservice/publisher/KafkaPostConsumerTest.java
+++ b/src/test/java/faang/school/postservice/publisher/KafkaPostConsumerTest.java
@@ -1,0 +1,97 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostCreatedEventDto;
+import faang.school.postservice.service.FeedService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaPostConsumerTest {
+
+    @Mock
+    private FeedService feedService;
+
+    @InjectMocks
+    private KafkaPostConsumer consumer;
+
+    @Test
+    @DisplayName("onPostCreated should add post to all follower feeds and acknowledge message")
+    void onPostCreated_shouldProcessAllFollowers_andAck() {
+
+        PostCreatedEventDto event = buildEvent(List.of(11L, 22L, 33L));
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        consumer.onPostCreated(event, ack);
+
+        for (Long followerId : event.followerIds()) {
+            verify(feedService).addPostToFeed(followerId, event.postId(), event.occurredAt());
+        }
+        verify(ack).acknowledge();
+        verifyNoMoreInteractions(ack);
+    }
+
+    @Test
+    @DisplayName("onPostCreated should call FeedService once per follower")
+    void onPostCreated_shouldCallFeedServicePerFollower() {
+
+        PostCreatedEventDto event = buildEvent(List.of(1L, 2L, 3L, 4L));
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        consumer.onPostCreated(event, ack);
+
+        verify(feedService, times(4)).addPostToFeed(anyLong(), eq(event.postId()), eq(event.occurredAt()));
+        verify(ack).acknowledge();
+    }
+
+    @Test
+    @DisplayName("onPostCreated should not acknowledge Kafka message when FeedService throws exception")
+    void onPostCreated_shouldNotAck_whenException() {
+
+        PostCreatedEventDto event = buildEvent(List.of(10L, 20L));
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        doThrow(new RuntimeException("boom"))
+                .when(feedService)
+                .addPostToFeed(eq(10L), eq(event.postId()), eq(event.occurredAt()));
+
+        assertThrows(RuntimeException.class, () -> consumer.onPostCreated(event, ack));
+
+        verify(feedService).addPostToFeed(10L, event.postId(), event.occurredAt());
+        verify(ack, never()).acknowledge();
+    }
+
+    @Test
+    @DisplayName("onPostCreated should handle event with empty followers list")
+    void onPostCreated_shouldAck_whenNoFollowers() {
+
+        PostCreatedEventDto event = buildEvent(List.of());
+        Acknowledgment ack = mock(Acknowledgment.class);
+
+        consumer.onPostCreated(event, ack);
+
+        verifyNoInteractions(feedService);
+        verify(ack).acknowledge();
+    }
+
+    private static PostCreatedEventDto buildEvent(List<Long> followers) {
+        return new PostCreatedEventDto(
+                UUID.randomUUID(),
+                Instant.parse("2025-12-28T00:00:00Z"),
+                999L,
+                null, // Publisher - keep null unless you need it
+                followers,
+                1
+        );
+    }
+}

--- a/src/test/java/faang/school/postservice/publisher/KafkaPostConsumerTest.java
+++ b/src/test/java/faang/school/postservice/publisher/KafkaPostConsumerTest.java
@@ -5,7 +5,8 @@ import faang.school.postservice.service.FeedService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.support.Acknowledgment;
 
@@ -14,7 +15,15 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class KafkaPostConsumerTest {

--- a/src/test/java/faang/school/postservice/publisher/PostCreatedKafkaProducerTest.java
+++ b/src/test/java/faang/school/postservice/publisher/PostCreatedKafkaProducerTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.SendResult;
@@ -15,9 +16,11 @@ import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PostCreatedKafkaProducerTest {

--- a/src/test/java/faang/school/postservice/publisher/PostCreatedKafkaProducerTest.java
+++ b/src/test/java/faang/school/postservice/publisher/PostCreatedKafkaProducerTest.java
@@ -1,0 +1,109 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostCreatedEventDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostCreatedKafkaProducerTest {
+
+    @Mock
+    private KafkaTemplate<String, PostCreatedEventDto> kafkaTemplate;
+
+    @InjectMocks
+    private PostCreatedKafkaProducer producer;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(
+                producer,
+                "postCreatedEventTopic",
+                "posts-created-topic"
+        );
+    }
+
+    @Test
+    @DisplayName("send should publish PostCreatedEvent to Kafka with postId as key")
+    void send_shouldPublishEventWithCorrectKeyAndTopic() {
+
+        PostCreatedEventDto event = buildEvent();
+        CompletableFuture<SendResult<String, PostCreatedEventDto>> future =
+                CompletableFuture.completedFuture(null);
+
+        when(kafkaTemplate.send(
+                eq("posts-created-topic"),
+                eq(String.valueOf(event.postId())),
+                eq(event)
+        )).thenReturn(future);
+
+        producer.send(event);
+
+        verify(kafkaTemplate).send(
+                "posts-created-topic",
+                String.valueOf(event.postId()),
+                event
+        );
+    }
+
+    @Test
+    @DisplayName("send should handle Kafka send failure gracefully")
+    void send_shouldHandleKafkaFailure() {
+
+        PostCreatedEventDto event = buildEvent();
+        CompletableFuture<SendResult<String, PostCreatedEventDto>> future =
+                new CompletableFuture<>();
+
+        when(kafkaTemplate.send(anyString(), anyString(), any()))
+                .thenReturn(future);
+
+
+        producer.send(event);
+
+        // simulate async failure
+        future.completeExceptionally(new RuntimeException("Kafka unavailable"));
+
+        verify(kafkaTemplate).send(
+                "posts-created-topic",
+                String.valueOf(event.postId()),
+                event
+        );
+    }
+
+    @Test
+    @DisplayName("send should be asynchronous and not block caller thread")
+    void send_shouldBeAsync() {
+
+        when(kafkaTemplate.send(anyString(), anyString(), any()))
+                .thenReturn(new CompletableFuture<>());
+
+        producer.send(buildEvent());
+
+        verify(kafkaTemplate).send(anyString(), anyString(), any());
+    }
+
+    private static PostCreatedEventDto buildEvent() {
+        return new PostCreatedEventDto(
+                UUID.randomUUID(),
+                Instant.parse("2025-12-28T00:00:00Z"),
+                123L,
+                null,
+                null,
+                1
+        );
+    }
+}

--- a/src/test/java/faang/school/postservice/publisher/PostCreatedKafkaPublisherTest.java
+++ b/src/test/java/faang/school/postservice/publisher/PostCreatedKafkaPublisherTest.java
@@ -1,0 +1,59 @@
+package faang.school.postservice.publisher;
+
+import faang.school.postservice.dto.post.PostCreatedEventDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostCreatedKafkaPublisherTest {
+
+    @Mock
+    private PostCreatedKafkaProducer producer;
+
+    @InjectMocks
+    private PostCreatedKafkaPublisher publisher;
+
+    @Test
+    @DisplayName("on should delegate PostCreatedEvent to Kafka producer")
+    void on_shouldDelegateToProducer() {
+        PostCreatedEventDto event = buildEvent();
+
+        publisher.on(event);
+
+        verify(producer).send(event);
+        verifyNoMoreInteractions(producer);
+    }
+
+    @Test
+    @DisplayName("on should propagate exception from Kafka producer")
+    void on_shouldPropagateException() {
+
+        PostCreatedEventDto event = buildEvent();
+        doThrow(new RuntimeException("Kafka error"))
+                .when(producer).send(event);
+
+        assertThrows(RuntimeException.class, () -> publisher.on(event));
+
+        verify(producer).send(event);
+    }
+
+    private static PostCreatedEventDto buildEvent() {
+        return new PostCreatedEventDto(
+                UUID.randomUUID(),
+                Instant.parse("2025-12-28T00:00:00Z"),
+                999L,
+                null,
+                null,
+                1
+        );
+    }
+}

--- a/src/test/java/faang/school/postservice/publisher/PostCreatedKafkaPublisherTest.java
+++ b/src/test/java/faang/school/postservice/publisher/PostCreatedKafkaPublisherTest.java
@@ -4,14 +4,17 @@ import faang.school.postservice.dto.post.PostCreatedEventDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Instant;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @ExtendWith(MockitoExtension.class)
 class PostCreatedKafkaPublisherTest {

--- a/src/test/java/faang/school/postservice/service/FeedServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/service/FeedServiceImplTest.java
@@ -1,0 +1,156 @@
+package faang.school.postservice.service;
+
+import faang.school.postservice.config.FeedRedisProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FeedServiceImplTest {
+
+    @Mock
+    private StringRedisTemplate redis;
+    @Mock
+    private FeedRedisProperties props;
+    @Mock
+    private ZSetOperations<String, String> zsetOps;
+
+    private FeedServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new FeedServiceImpl(redis, props);
+    }
+
+    @Test
+    @DisplayName("addPostToFeed should add post to Redis feed when post is new")
+    void addPostToFeed_shouldAdd_whenNew() {
+
+        when(props.getKeyPrefix()).thenReturn("feed:");
+        when(props.getMaxSize()).thenReturn(1000);
+
+        long followerId = 10L;
+        long postId = 777L;
+        Instant occurredAt = Instant.parse("2025-12-28T00:00:00Z");
+
+        when(redis.execute(any(), anyList(), anyString(), anyString(), anyString()))
+                .thenReturn(1L);
+
+        service.addPostToFeed(followerId, postId, occurredAt);
+
+        verify(redis).execute(
+                any(),
+                eq(List.of("feed:" + followerId)),
+                anyString(),
+                eq(String.valueOf(postId)),
+                eq("1000")
+        );
+    }
+
+    @Test
+    @DisplayName("addPostToFeed should ignore duplicate post when Lua script returns 0")
+    void addPostToFeed_shouldIgnoreDuplicate() {
+
+        when(props.getKeyPrefix()).thenReturn("feed:");
+        when(props.getMaxSize()).thenReturn(1000);
+
+        when(redis.execute(any(), anyList(), anyString(), anyString(), anyString()))
+                .thenReturn(0L);
+
+        service.addPostToFeed(1L, 2L, Instant.now());
+
+        verify(redis).execute(any(), anyList(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("addPostToFeed should calculate score using occurredAt timestamp and postId")
+    void addPostToFeed_shouldCalculateScoreCorrectly() {
+
+        when(props.getKeyPrefix()).thenReturn("feed:");
+        when(props.getMaxSize()).thenReturn(1000);
+
+        long followerId = 5L;
+        long postId = 1234L; // %1000 = 234
+        Instant occurredAt = Instant.ofEpochMilli(1_700_000_000_000L);
+
+        when(redis.execute(any(), anyList(), anyString(), anyString(), anyString()))
+                .thenReturn(1L);
+
+        ArgumentCaptor<String> scoreCaptor = ArgumentCaptor.forClass(String.class);
+
+        service.addPostToFeed(followerId, postId, occurredAt);
+
+        verify(redis).execute(
+                any(),
+                eq(List.of("feed:" + followerId)),
+                scoreCaptor.capture(),
+                eq(String.valueOf(postId)),
+                eq("1000")
+        );
+
+        long expectedScore = occurredAt.toEpochMilli() * 1_000 + (postId % 1_000);
+        assertEquals(String.valueOf(expectedScore), scoreCaptor.getValue());
+    }
+
+    @Test
+    @DisplayName("addPostToFeed should propagate exception when Redis execution fails")
+    void addPostToFeed_shouldPropagateException() {
+
+        when(props.getKeyPrefix()).thenReturn("feed:");
+        when(props.getMaxSize()).thenReturn(1000);
+
+        when(redis.execute(any(), anyList(), anyString(), anyString(), anyString()))
+                .thenThrow(new RuntimeException("Redis down"));
+
+        RuntimeException ex = assertThrows(
+                RuntimeException.class,
+                () -> service.addPostToFeed(1L, 2L, Instant.now())
+        );
+        assertEquals("Redis down", ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("getLatestPosts should return latest posts mapped to Long")
+    void getLatestPosts_shouldReturnLatestPosts() {
+
+        when(props.getKeyPrefix()).thenReturn("feed:");
+        when(redis.opsForZSet()).thenReturn(zsetOps);
+
+        when(zsetOps.reverseRange("feed:42", 0, 2))
+                .thenReturn(Set.of("101", "102", "103"));
+
+        List<Long> result = service.getLatestPosts(42L, 3);
+
+        assertEquals(3, result.size());
+        verify(zsetOps).reverseRange("feed:42", 0, 2);
+    }
+
+    @Test
+    @DisplayName("getLatestPosts should return empty list when feed does not exist")
+    void getLatestPosts_shouldReturnEmptyList_whenNoFeed() {
+
+        when(props.getKeyPrefix()).thenReturn("feed:");
+        when(redis.opsForZSet()).thenReturn(zsetOps);
+
+        when(zsetOps.reverseRange("feed:1", 0, 9))
+                .thenReturn(Set.of());
+
+        List<Long> result = service.getLatestPosts(1L, 10);
+
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/faang/school/postservice/service/FeedServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/service/FeedServiceImplTest.java
@@ -5,7 +5,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.*;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
@@ -14,9 +15,16 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class FeedServiceImplTest {

--- a/src/test/java/faang/school/postservice/service/redis/FeedServiceIntegrationTest.java
+++ b/src/test/java/faang/school/postservice/service/redis/FeedServiceIntegrationTest.java
@@ -1,0 +1,106 @@
+package faang.school.postservice.service.redis;
+
+import faang.school.postservice.config.FeedRedisProperties;
+import faang.school.postservice.service.FeedService;
+import faang.school.postservice.service.FeedServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataRedisTest
+@Testcontainers
+@Import(FeedServiceImpl.class)
+@EnableConfigurationProperties(FeedRedisProperties.class)
+class FeedServiceIntegrationTest {
+
+    @Container
+    static final GenericContainer<?> redisContainer =
+            new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProps(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
+        registry.add("app.feed.redis.max-size", () -> 500);
+        registry.add("app.feed.redis.key-prefix", () -> "feed:v1:");
+    }
+
+    @Autowired
+    FeedService feedService;
+
+    @Autowired
+    StringRedisTemplate redis;
+
+    @Autowired
+    FeedRedisProperties feedProps;
+
+    @BeforeEach
+    void cleanRedis() {
+        redis.getConnectionFactory().getConnection().serverCommands().flushAll();
+    }
+
+    @Test
+    @DisplayName("addPostToFeed: adds postIds and getLatestPosts returns newest first")
+    void addPostToFeed_returnsNewestFirst() {
+        long followerId = 101L;
+
+        feedService.addPostToFeed(followerId, 1L, Instant.parse("2025-12-26T10:00:00Z"));
+        feedService.addPostToFeed(followerId, 2L, Instant.parse("2025-12-26T10:00:01Z"));
+        feedService.addPostToFeed(followerId, 3L, Instant.parse("2025-12-26T10:00:02Z"));
+
+        List<Long> latest = feedService.getLatestPosts(followerId, 10);
+
+        assertThat(latest).containsExactly(3L, 2L, 1L);
+    }
+
+    @Test
+    @DisplayName("addPostToFeed: idempotent (same postId twice doesn't duplicate in ZSET)")
+    void addPostToFeed_isIdempotent() {
+        long followerId = 202L;
+        Instant ts = Instant.parse("2025-12-26T10:00:00Z");
+
+        feedService.addPostToFeed(followerId, 42L, ts);
+        feedService.addPostToFeed(followerId, 42L, ts); // duplicate delivery
+
+        String key = feedProps.getKeyPrefix() + followerId;
+        Long size = redis.opsForZSet().zCard(key);
+
+        assertThat(size).isEqualTo(1L);
+        assertThat(feedService.getLatestPosts(followerId, 10)).containsExactly(42L);
+    }
+
+    @Test
+    @DisplayName("addPostToFeed: trims to maxSize (keeps newest posts, drops oldest)")
+    void addPostToFeed_trimsToMaxSize() {
+        long followerId = 303L;
+
+        feedProps.setMaxSize(3);
+
+        feedService.addPostToFeed(followerId, 1L, Instant.parse("2025-12-26T10:00:00Z"));
+        feedService.addPostToFeed(followerId, 2L, Instant.parse("2025-12-26T10:00:01Z"));
+        feedService.addPostToFeed(followerId, 3L, Instant.parse("2025-12-26T10:00:02Z"));
+        feedService.addPostToFeed(followerId, 4L, Instant.parse("2025-12-26T10:00:03Z"));
+        feedService.addPostToFeed(followerId, 5L, Instant.parse("2025-12-26T10:00:04Z"));
+
+        String key = feedProps.getKeyPrefix() + followerId;
+        Long size = redis.opsForZSet().zCard(key);
+
+        assertThat(size).isEqualTo(3L);
+        assertThat(feedService.getLatestPosts(followerId, 10)).containsExactly(5L, 4L, 3L);
+    }
+}

--- a/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
@@ -8,6 +8,7 @@ import faang.school.postservice.config.context.UserContext;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
 import faang.school.postservice.dto.post.PostCreatedEventDto;
 import faang.school.postservice.dto.post.PostResponseDto;
+import faang.school.postservice.dto.post.PublisherType;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.project.ProjectDto;
 import faang.school.postservice.dto.text.MatchDto;
@@ -668,7 +669,7 @@ class PostServiceImplTest {
         assertNotNull(event.occurredAt());
         assertEquals(POST_ID, event.postId());
         assertEquals(followerIds, event.followerIds());
-        assertEquals(faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.USER, event.publisher().type());
+        assertEquals(PublisherType.USER, event.publisher().type());
         assertEquals(AUTHOR_ID, event.publisher().id());
         assertEquals(1, event.version());
     }
@@ -686,15 +687,15 @@ class PostServiceImplTest {
 
         verify(followersService, never()).getFollowerIds(any());
 
-        ArgumentCaptor<faang.school.postservice.dto.post.PostCreatedEventDto> captor =
-                ArgumentCaptor.forClass(faang.school.postservice.dto.post.PostCreatedEventDto.class);
+        ArgumentCaptor<PostCreatedEventDto> captor =
+                ArgumentCaptor.forClass(PostCreatedEventDto.class);
 
         verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
 
         var event = captor.getValue();
         assertEquals(POST_ID, event.postId());
         assertTrue(event.followerIds().isEmpty());
-        assertEquals(faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.PROJECT, event.publisher().type());
+        assertEquals(PublisherType.PROJECT, event.publisher().type());
         assertEquals(PROJECT_ID, event.publisher().id());
     }
 

--- a/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
+++ b/src/test/java/faang/school/postservice/util/post/PostServiceImplTest.java
@@ -6,6 +6,7 @@ import faang.school.postservice.client.UserServiceClient;
 import faang.school.postservice.config.context.LanguageToolConfig;
 import faang.school.postservice.config.context.UserContext;
 import faang.school.postservice.dto.post.CreatePostRequestDto;
+import faang.school.postservice.dto.post.PostCreatedEventDto;
 import faang.school.postservice.dto.post.PostResponseDto;
 import faang.school.postservice.dto.post.UpdatePostRequestDto;
 import faang.school.postservice.dto.project.ProjectDto;
@@ -18,6 +19,7 @@ import faang.school.postservice.mapper.post.PostMapper;
 import faang.school.postservice.model.Post;
 import faang.school.postservice.repository.PostRepository;
 import faang.school.postservice.scheduler.ThreadPoolConfig;
+import faang.school.postservice.service.FollowersService;
 import faang.school.postservice.service.PostServiceImpl;
 import feign.FeignException;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +31,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.http.ResponseEntity;
 
 import java.lang.reflect.Field;
@@ -55,6 +58,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import org.mockito.ArgumentCaptor;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceImplTest {
@@ -92,6 +97,10 @@ class PostServiceImplTest {
     private FeignLanguageToolClient feignLanguageTool;
     @Mock
     private UserContext userContext;
+    @Mock
+    FollowersService followersService;
+    @Mock
+    ApplicationEventPublisher applicationEventPublisher;
     @Spy
     private PostMapper postMapper = Mappers.getMapper(PostMapper.class);
     private Post postDbEntity;
@@ -632,4 +641,101 @@ class PostServiceImplTest {
         assertDoesNotThrow(() -> service.processTextChecking());
         verify(postRepository, never()).save(any(Post.class));
     }
+
+    @Test
+    @DisplayName("publish: USER publisher -> loads followerIds and publishes Spring event")
+    void publish_user_publishesEvent_withFollowers() {
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(postDbEntity));
+        when(postRepository.save(any(Post.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        List<Long> followerIds = List.of(101L, 102L, 103L);
+        when(followersService.getFollowerIds(AUTHOR_ID)).thenReturn(followerIds);
+
+        PostResponseDto out = service.publish(POST_ID);
+
+        assertTrue(out.published());
+        assertNotNull(out.publishedAt());
+
+        verify(followersService, times(1)).getFollowerIds(AUTHOR_ID);
+
+        ArgumentCaptor<PostCreatedEventDto> captor =
+                ArgumentCaptor.forClass(PostCreatedEventDto.class);
+
+        verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
+
+        var event = captor.getValue();
+        assertNotNull(event.eventId());
+        assertNotNull(event.occurredAt());
+        assertEquals(POST_ID, event.postId());
+        assertEquals(followerIds, event.followerIds());
+        assertEquals(faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.USER, event.publisher().type());
+        assertEquals(AUTHOR_ID, event.publisher().id());
+        assertEquals(1, event.version());
+    }
+
+    @Test
+    @DisplayName("publish: PROJECT publisher -> does not load followers, publishes event with empty followerIds")
+    void publish_project_publishesEvent_withoutFollowersCall() {
+        Post projectPost = buildPost(POST_ID, null, PROJECT_ID, CONTENT, false, false,
+                LocalDateTime.now().minusHours(1), null);
+
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(projectPost));
+        when(postRepository.save(any(Post.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        service.publish(POST_ID);
+
+        verify(followersService, never()).getFollowerIds(any());
+
+        ArgumentCaptor<faang.school.postservice.dto.post.PostCreatedEventDto> captor =
+                ArgumentCaptor.forClass(faang.school.postservice.dto.post.PostCreatedEventDto.class);
+
+        verify(applicationEventPublisher, times(1)).publishEvent(captor.capture());
+
+        var event = captor.getValue();
+        assertEquals(POST_ID, event.postId());
+        assertTrue(event.followerIds().isEmpty());
+        assertEquals(faang.school.postservice.dto.post.PostCreatedEventDto.PublisherType.PROJECT, event.publisher().type());
+        assertEquals(PROJECT_ID, event.publisher().id());
+    }
+
+    @Test
+    @DisplayName("publish: invalid publisher (both authorId and projectId) -> throws")
+    void publish_bothPublishers_throws() {
+        Post invalid = buildPost(POST_ID, AUTHOR_ID, PROJECT_ID, CONTENT, false, false,
+                LocalDateTime.now().minusHours(1), null);
+
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(invalid));
+
+        assertThrows(IllegalStateException.class, () -> service.publish(POST_ID));
+
+        verify(postRepository, never()).save(any());
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("publish: invalid publisher (no authorId and no projectId) -> throws")
+    void publish_noPublisher_throws() {
+        Post invalid = buildPost(POST_ID, null, null, CONTENT, false, false,
+                LocalDateTime.now().minusHours(1), null);
+
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(invalid));
+
+        assertThrows(IllegalStateException.class, () -> service.publish(POST_ID));
+
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("publish: followersService fails -> event not published")
+    void publish_followersServiceFails_eventNotPublished() {
+        when(postRepository.findById(POST_ID)).thenReturn(Optional.of(postDbEntity));
+        when(postRepository.save(any(Post.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        when(followersService.getFollowerIds(AUTHOR_ID)).thenThrow(new RuntimeException("user-service down"));
+
+        assertThrows(RuntimeException.class, () -> service.publish(POST_ID));
+
+        verify(applicationEventPublisher, never()).publishEvent(any());
+    }
+
 }


### PR DESCRIPTION
Слушатель Kafka-эвентов для постов

Задание
Создать слушателя событий KafkaPostConsumer, который слушает Kafka-топик posts, получая соответствующие эвенты. Использовать аннотацию @KafkaListener

Данный потребитель должен принимать событие и для всех id подписчиков, которые в нем содержатся, добавлять/изменять соответствующие записи в коллекции Feed в Redis

Для работы с Redis можно использовать этот туториал:

[Introduction to Spring Data Redis | Baeldung|https://www.baeldung.com/spring-data-redis-tutorial]

Feed представляет собой ассоциацию: ключ - id подписчика, значение - набор из 500 (max) постов в его фиде. Подумать, какую коллекцию следует использовать для хранения набора этих постов. Требования: посты не должны дублироваться, посты должны располагаться в хронологическом порядке (новые - сверху)

Если фид пользователя уже заполнен (500), то удалять пост в конце фида, а новый добавлять сверху

Убедиться в корректной обработке конкурентных эвентов. Два поста в один и тот же фид могут прилететь одновременно. В Redis нет транзакций.

Убедиться, что максимальный размер кэша фида можно менять через конфиг

Делать ack в Kafka на обработку эвента поста только после того, как все подписчики успешно обработаны в рамках данного эвента

Подумать, почему при падении сервера и повторной обработке того же самого эвента посты не будут задублированы в фиде пользователей, для которых они были добавлены в фид при первой неудачной обработке события. Как структура данных в Redis решает эту проблему?


<img width="2938" height="1844" alt="image" src="https://github.com/user-attachments/assets/b236351d-7799-4996-ba4b-b4f7c7174098" />

